### PR TITLE
Symmetry eigenvalues fix

### DIFF
--- a/devdocs/docs.md
+++ b/devdocs/docs.md
@@ -164,20 +164,20 @@ $I = (i, α)$; and $𝐑,𝐑'$ run over the lattice translations.
 We can apply the same Fourier transform to go into reciprocal space:
 
 $$
-ĉ_{I,𝐑} = \frac{1}{\sqrt{N}} \sum_{𝗸} e^{-i𝗸·(𝐑+𝗾_α)} â_{I,𝗸},
+ĉ_{I,𝐑} = \frac{1}{\sqrt{N}} \sum_{𝗸} e^{i𝗸·(𝐑+𝗾_α)} â_{I,𝗸},
 $$
 obtaining:
 
 $$
-Ĥ = \frac{1}{N} \sum_{IJ,𝐑𝐑'} h_{IJ,𝘁} \sum_{𝗸𝗸'} e^{i𝗸·(𝐑+𝗾_α)} e^{-i𝗸'·(𝐑'+𝗾_β)}
+Ĥ = \frac{1}{N} \sum_{IJ,𝐑𝐑'} h_{IJ,𝘁} \sum_{𝗸𝗸'} e^{-i𝗸·(𝐑+𝗾_α)} e^{i𝗸'·(𝐑'+𝗾_β)}
 â^†_{I,𝗸} â_{J,𝗸'} \\
-= \frac{1}{N} \sum_{IJ,𝘁,𝗸𝗸'} h_{IJ,𝘁} \left[ \sum_{𝐑'} e^{i(𝗸-𝗸')·𝐑'} \right] 
-e^{i𝗸·(𝘁+𝗾_α)} e^{-i𝗸'·𝗾_β} â^†_{I,𝗸} â_{J,𝗸'} \\
-= \sum_{IJ,𝘁,𝗸𝗸'} h_{IJ,𝘁} δ_{𝗸𝗸'} e^{i𝗸·𝗾_α} e^{-i𝗸'·(𝐭 + 𝗾_β)} â^†_{I,𝗸} â_{J,𝗸'} \\
-= \sum_{IJ,𝘁,𝗸} h_{IJ,𝘁} e^{-i𝗸·(𝘁+𝗾_β-𝗾_α)} â^†_{I,𝗸} â_{J,𝗸} \\
+= \frac{1}{N} \sum_{IJ,𝘁,𝗸𝗸'} h_{IJ,𝘁} \left[ \sum_{𝐑'} e^{-i(𝗸-𝗸')·𝐑'} \right] 
+e^{-i𝗸·(𝘁+𝗾_α)} e^{i𝗸'·𝗾_β} â^†_{I,𝗸} â_{J,𝗸'} \\
+= \sum_{IJ,𝘁,𝗸𝗸'} h_{IJ,𝘁} δ_{𝗸𝗸'} e^{-i𝗸·𝗾_α} e^{i𝗸'·(𝐭 + 𝗾_β)} â^†_{I,𝗸} â_{J,𝗸'} \\
+= \sum_{IJ,𝘁,𝗸} h_{IJ,𝘁} e^{i𝗸·(𝘁+𝗾_β-𝗾_α)} â^†_{I,𝗸} â_{J,𝗸} \\
 = \sum_{IJ,𝗸} h_{IJ,𝗸} â^†_{I,𝗸} â_{J,𝗸},
 $$
-where he have defined: $h_{IJ,𝗸} = \sum_𝘁 h_{IJ,𝘁} e^{-i𝗸·(𝘁+𝗾_β-𝗾_α)}$.
+where he have defined: $h_{IJ,𝗸} = \sum_𝘁 h_{IJ,𝘁} e^{i𝗸·(𝘁+𝗾_β-𝗾_α)}$.
 
 These creation and annihilation operators will correspond to a basis set of functions such as
 $\ket{φ_{I,𝗸}} = â^†_{I,𝗸} \ket{0}$.

--- a/devdocs/docs.md
+++ b/devdocs/docs.md
@@ -159,7 +159,7 @@ $I = (i, α)$; and $𝐑,𝐑'$ run over the lattice translations.
 
 > [!WARNING]
 > Notice that we have assumed that hopping terms only depends on relative distances.
-> We are going to denote $𝘁 ≡ 𝐑 - 𝐑'$.
+> We are going to denote $𝘁 ≡ 𝐑' - 𝐑$.
 
 We can apply the same Fourier transform to go into reciprocal space:
 
@@ -173,11 +173,11 @@ $$
 â^†_{I,𝗸} â_{J,𝗸'} \\
 = \frac{1}{N} \sum_{IJ,𝘁,𝗸𝗸'} h_{IJ,𝘁} \left[ \sum_{𝐑'} e^{i(𝗸-𝗸')·𝐑'} \right] 
 e^{i𝗸·(𝘁+𝗾_α)} e^{-i𝗸'·𝗾_β} â^†_{I,𝗸} â_{J,𝗸'} \\
-= \sum_{IJ,𝘁,𝗸𝗸'} h_{IJ,𝘁} δ_{𝗸𝗸'} e^{i𝗸·(𝘁+𝗾_α)} e^{-i𝗸'·𝗾_β} â^†_{I,𝗸} â_{J,𝗸'} \\
-= \sum_{IJ,𝘁,𝗸} h_{IJ,𝘁} e^{i𝗸·𝗸·(𝘁+𝗾_α-𝗾_β)} â^†_{I,𝗸} â_{J,𝗸} \\
+= \sum_{IJ,𝘁,𝗸𝗸'} h_{IJ,𝘁} δ_{𝗸𝗸'} e^{i𝗸·𝗾_α} e^{-i𝗸'·(𝐭 + 𝗾_β)} â^†_{I,𝗸} â_{J,𝗸'} \\
+= \sum_{IJ,𝘁,𝗸} h_{IJ,𝘁} e^{-i𝗸·(𝘁+𝗾_β-𝗾_α)} â^†_{I,𝗸} â_{J,𝗸} \\
 = \sum_{IJ,𝗸} h_{IJ,𝗸} â^†_{I,𝗸} â_{J,𝗸},
 $$
-where he have defined: $h_{IJ,𝗸} = \sum_𝘁 h_{IJ,𝘁} e^{i𝗸·𝗸·(𝘁+𝗾_α-𝗾_β)}$.
+where he have defined: $h_{IJ,𝗸} = \sum_𝘁 h_{IJ,𝘁} e^{-i𝗸·(𝘁+𝗾_β-𝗾_α)}$.
 
 These creation and annihilation operators will correspond to a basis set of functions such as
 $\ket{φ_{I,𝗸}} = â^†_{I,𝗸} \ket{0}$.

--- a/devdocs/fourier.md
+++ b/devdocs/fourier.md
@@ -1,0 +1,92 @@
+# Notes on Fourier Transforms and Different Conventions
+
+In this document, I present a brief overview of Fourier transforms, focusing on two conventions that have been used during the development of this codebase.
+
+Specifically, we distinguish between two common conventions for the Fourier transform. For lack of standard terminology, we will refer to them as:
+
+1. **Convention 1:** This is the convention used by [PythTB](https://www.physics.rutgers.edu/pythtb/index.html), and it is particularly well-suited for the computation of Berry phases and related quantities.
+
+2. **Convention 2:** This convention is adopted in [this review article](https://www.annualreviews.org/content/journals/10.1146/annurev-conmatphys-041720-124134), and is generally more prevalent in the literature.
+
+In the following sections, we will carefully examine both conventions and demonstrate how they are related to each other.
+
+## Convention 1
+
+This convention defines the Fourier transform as:
+
+```math
+φ_{I,𝐤}(𝐫) = \frac{1}{\sqrt{N}} \sum_𝐭 e^{i𝐤·(𝐭+𝐪_α)} ψ_I(𝐫-𝐭),
+```
+which yields the inverse Fourier transform:
+
+```math
+ψ_I(𝐫-𝐭) = \frac{1}{\sqrt{N}} \sum_𝐤 e^{-i𝐤·(𝐭+𝐪_α)} φ_{I,𝐤}(𝐫)
+```
+
+In our framework, we are also interested in the quantization of these functions in order to construct the tight-binding Hamiltonian. We can express the same relations in the second-quantized notation as:
+
+```math
+\ket{φ_{I,𝐤}} = \frac{1}{\sqrt{N}} \sum_𝐭 e^{i𝐤·(𝐭+𝐪_α)} \ket{ψ_{I,𝐭}},
+```
+and:
+
+```math
+\ket{ψ_{I,𝐭}} = \frac{1}{\sqrt{N}} \sum_𝐤 e^{-i𝐤·(𝐭+𝐪_α)} \ket{φ_{I,𝐤}}
+```
+
+This quantization also determines how the creation and annihilation operators transform under this convention:
+
+```math
+â_{I,𝐤}^† \ket{\text{vac}} = \frac{1}{\sqrt{N}} \sum_𝐭 e^{i𝐤·(𝐭+𝐪_α)} ĉ_{I,𝐭}^† \ket{\text{vac}} ⇒ â_{I,𝐤}^† = \frac{1}{\sqrt{N}} \sum_𝐭 e^{i𝐤·(𝐭+𝐪_α)} ĉ_{I,𝐭}^†,
+```
+and similarly:
+
+```math
+ĉ_{I,𝐭}^† = \frac{1}{\sqrt{N}} \sum_𝐤 e^{-i𝐤·(𝐭+𝐪_α)} â_{I,𝐤}^†
+```
+
+## Convention 2
+
+This convention defines the Fourier transform as:
+
+```math
+\tilde{φ}_{I,𝐤}(𝐫) = \frac{1}{\sqrt{N}} \sum_𝐭 e^{i𝐤·𝐭} ψ_I(𝐫-𝐭),
+```
+which yields the inverse Fourier transform:
+
+```math
+ψ_I(𝐫-𝐭) = \frac{1}{\sqrt{N}} \sum_𝐤 e^{-i𝐤·𝐭} \tilde{φ}_{I,𝐤}(𝐫)
+```
+
+In our framework, we are also interested in the quantization of these functions in order to construct the tight-binding Hamiltonian. We can express the same relations in the second-quantized notation as:
+
+```math
+\ket{\tilde{φ}_{I,𝐤}} = \frac{1}{\sqrt{N}} \sum_𝐭 e^{i𝐤·𝐭} \ket{ψ_{I,𝐭}},
+```
+and:
+
+```math
+\ket{ψ_{I,𝐭}} = \frac{1}{\sqrt{N}} \sum_𝐤 e^{-i𝐤·𝐭} \ket{\tilde{φ}_{I,𝐤}}
+```
+
+This quantization also determines how the creation and annihilation operators transform under this convention:
+
+```math
+\hat{\tilde{a}}_{I,𝐤}^† \ket{\text{vac}} = \frac{1}{\sqrt{N}} \sum_𝐭 e^{i𝐤·𝐭} ĉ_{I,𝐭}^† \ket{\text{vac}} ⇒ \hat{\tilde{a}}_{I,𝐤}^† = \frac{1}{\sqrt{N}} \sum_𝐭 e^{i𝐤·𝐭} ĉ_{I,𝐭}^†,
+```
+and similarly:
+
+```math
+ĉ_{I,𝐭}^† = \frac{1}{\sqrt{N}} \sum_𝐤 e^{-i𝐤·𝐭} \hat{\tilde{a}}_{I,𝐤}^†
+```
+
+## How they relate to each other
+
+- **Convention 1:** $\ket{φ_{I,𝐤}} = \frac{1}{\sqrt{N}} \sum_𝐭 e^{i𝐤·(𝐭+𝐪_α)} \ket{ψ_{I,𝐭}}$
+- **Convention 2:** $\ket{\tilde{φ}_{I,𝐤}} = \frac{1}{\sqrt{N}} \sum_𝐭 e^{i𝐤·𝐭} \ket{ψ_{I,𝐭}}$
+
+Then we have that:
+
+```math
+\ket{\tilde{φ}_{I,𝐤}} = e^{-i𝐤·𝐪_α} \ket{φ_{I,𝐤}}
+```

--- a/devdocs/trs_notes.md
+++ b/devdocs/trs_notes.md
@@ -506,34 +506,33 @@ of the WP, i.e., $I = (i, α)$; and $\mathbf{R,R}'$ run over the lattice transla
 
 > [!WARNING]
 > Notice that we have assumed that hopping terms only depends on relative distances.
-> We are going to denote $\mathbf{t \equiv R - R}'$.
+> We are going to denote $\mathbf{t \equiv R' - R}$.
 
-We can apply the same Fourier transform to go into reciprocal space:
+To be consistent with the previous Fourier transform picked, we need to impose the following transformation to the creation operator:
 
 $$
-\hat{c}_{I,\mathbf{R}} = \frac{1}{\sqrt{N}} \sum_{\mathbf{k}} e^{-i\mathbf{k·(R+q_α)}}
-\hat{a}_{I,\mathbf{k}},
+ĉ_{I,𝐑}^† = \frac{1}{\sqrt{N}} \sum_{𝐤} e^{-i𝐤·(𝐑+𝐪_α)} â_{I,𝐤}^†,
 $$
 
 obtaining:
 
 $$
 \hat{H} = \frac{1}{N} \sum_{IJ,\mathbf{RR}'} h_{IJ,\mathbf{t}} \sum_{\mathbf{kk}'}
-e^{i\mathbf{k·(R+q_α)}} e^{-i\mathbf{k'·(R'+q_β)}} \hat{a}^\dagger_{I,\mathbf{k}} 
+e^{-i\mathbf{k·(R+q_α)}} e^{i\mathbf{k'·(R'+q_β)}} \hat{a}^\dagger_{I,\mathbf{k}} 
 \hat{a}_{J,\mathbf{k}'} \\
 = \frac{1}{N} \sum_{IJ,\mathbf{t},\mathbf{kk}'} h_{IJ,\mathbf{t}} 
-\left[ \sum_{\mathbf{R}'} e^{i\mathbf{(k-k')·R+'}} \right] e^{i\mathbf{k·(t+q_α)}} 
-e^{-i\mathbf{k'·q_β}} \hat{a}^\dagger_{I,\mathbf{k}} \hat{a}_{J,\mathbf{k}'} \\
+\left[ \sum_{\mathbf{R}'} e^{i\mathbf{(k'-k)·R}} \right] e^{i\mathbf{k·(t-q_α)}} 
+e^{i\mathbf{k'·q_β}} \hat{a}^\dagger_{I,\mathbf{k}} \hat{a}_{J,\mathbf{k}'} \\
 = \sum_{IJ,\mathbf{t},\mathbf{kk}'} h_{IJ,\mathbf{t}} 
-\delta_{\mathbf{k,k'}} e^{i\mathbf{k·(t+q_α)}} e^{-i\mathbf{k'·q_β}} 
+\delta_{\mathbf{k,k'}} e^{i\mathbf{k·(t-q_α)}} e^{i\mathbf{k'·q_β}} 
 \hat{a}^\dagger_{I,\mathbf{k}} \hat{a}_{J,\mathbf{k}'} \\
 = \sum_{IJ,\mathbf{t},\mathbf{k}} h_{IJ,\mathbf{t}} 
-e^{i\mathbf{k·(t+q_α-q_β)}} \hat{a}^\dagger_{I,\mathbf{k}} \hat{a}_{J,\mathbf{k}} \\
+e^{i\mathbf{k·(t+q_β-q_α)}} \hat{a}^\dagger_{I,\mathbf{k}} \hat{a}_{J,\mathbf{k}} \\
 = \sum_{IJ,\mathbf{k}} h_{IJ,\mathbf{k}} \hat{a}^\dagger_{I,\mathbf{k}} 
 \hat{a}_{J,\mathbf{k}},
 $$
 where he have defined: $h_{IJ,\mathbf{k}} = \sum_\mathbf{t} h_{IJ,\mathbf{t}}
-e^{i\mathbf{k·(t+q_α-q_β)}}$.
+e^{i\mathbf{k·(t+q_β-q_α)}}$.
 
 #### Quantization of the representations
 

--- a/examples/graphene.jl
+++ b/examples/graphene.jl
@@ -1,9 +1,21 @@
 using Pkg
 Pkg.activate(@__DIR__)
 using Crystalline, SymmetricTightBinding
+using Brillouin, GLMakie
 
 sgnum, D = 17, 2
 brs = calc_bandreps(sgnum, Val(D))
 cbr = @composite brs[5]
 
-tb_model = tb_hamiltonian(cbr)
+tbm = tb_hamiltonian(cbr)
+
+ptbm = tbm(randn(length(tbm)))
+
+Rs = directbasis(sgnum, Val(2))
+
+kp = irrfbz_path(sgnum, Rs)
+kpi = interpolate(kp, 200) # aim for 200 interpolations points
+
+Es = spectrum(ptbm, kpi); # a 200×2 Matrix
+
+plot(kpi, Es; annotations = collect_irrep_annotations(ptbm))

--- a/examples/sg224.jl
+++ b/examples/sg224.jl
@@ -8,6 +8,9 @@ brs = calc_bandreps(sgnum, Val(D))
 cbr = @composite brs[13] + brs[19]
 Rs = [[0, 0, 0]]
 
-tb_model = tb_hamiltonian(cbr, Rs)
+tbm = tb_hamiltonian(cbr, Rs)
 
-hops = obtain_symmetry_related_hoppings(Rs, brs[13], brs[19])
+ptbm = tbm(randn(length(tbm)))
+
+println(SymmetryVector(cbr))
+println(collect_compatible(ptbm))

--- a/src/symmetry_analysis.jl
+++ b/src/symmetry_analysis.jl
@@ -101,6 +101,10 @@ function symmetry_eigenvalues(
     #     such phases here. Longer term, we might want to not do that (change to 
     #     "Convention 1") though since it could simplify the induced rep phases to an 
     #     overall phase instead of the tᵦₐ-business
+    # NOTE: maybe the last comment is not the best since the bloch periodic functions are 
+    #       periodic in real space but not in reciprocal space. This means that we will
+    #       need to correct such phases manually. Changing to "Convention 2", as we do now,
+    #       might be the best option for simplicity.
     _, vs = solve(ptbm, k; bloch_phase = Val(true))
     symeigs = Matrix{ComplexF64}(undef, length(ops), ptbm.tbm.N)
     for (j, sgrep) in enumerate(sgreps)

--- a/src/symmetry_analysis.jl
+++ b/src/symmetry_analysis.jl
@@ -97,14 +97,16 @@ function symmetry_eigenvalues(
     length(sgreps) == length(ops) || error("length of `sgreps` must match length of `ops`")
 
     # NB: Currently, the site-symmetry induced reps assume the "Convention 2" Fourier
-    #     transform, which does depend on "in-unit-cell" coordinates; so we must add
-    #     such phases here. Longer term, we might want to not do that (change to 
-    #     "Convention 1") though since it could simplify the induced rep phases to an 
-    #     overall phase instead of the tᵦₐ-business
-    # NOTE: maybe the last comment is not the best since the bloch periodic functions are 
+    #     transform. This Fourier transform doesn't depend on "in-unit-cell" coordinates;
+    #     so we must add such phases here, because we use Convention 1 for the Hamiltonian. 
+    #     Longer term, we might want to not do that (change to "Convention 1") though since
+    #     it could simplify the induced rep phases to an overall phase instead of the 
+    #     tᵦₐ-business
+    #
+    # NOTE: maybe the last idea is not the best since the bloch periodic functions are 
     #       periodic in real space but not in reciprocal space. This means that we will
     #       need to correct such phases manually. Changing to "Convention 2", as we do now,
-    #       might be the best option for simplicity.
+    #       might be the best option for simplicity and clarity.
     _, vs = solve(ptbm, k; bloch_phase = Val(true))
     symeigs = Matrix{ComplexF64}(undef, length(ops), ptbm.tbm.N)
     for (j, sgrep) in enumerate(sgreps)

--- a/src/symmetry_analysis.jl
+++ b/src/symmetry_analysis.jl
@@ -96,11 +96,12 @@ function symmetry_eigenvalues(
     length(k) == D || error("dimension mismatch")
     length(sgreps) == length(ops) || error("length of `sgreps` must match length of `ops`")
 
-    # NB: Currently, the site-symmetry induced reps assume the "Convention 1" Fourier
-    #     transform, which doesn't depend on "in-unit-cell" coordinates; so we don't add
-    #     such phases here. Longer term, we might want to do that though since it could
-    #     simplify the induced rep phases to an overall phase instead of the tᵦₐ-business
-    _, vs = solve(ptbm, k; bloch_phase = Val(false))
+    # NB: Currently, the site-symmetry induced reps assume the "Convention 2" Fourier
+    #     transform, which does depend on "in-unit-cell" coordinates; so we must add
+    #     such phases here. Longer term, we might want to not do that (change to 
+    #     "Convention 1") though since it could simplify the induced rep phases to an 
+    #     overall phase instead of the tᵦₐ-business
+    _, vs = solve(ptbm, k; bloch_phase = Val(true))
     symeigs = Matrix{ComplexF64}(undef, length(ops), ptbm.tbm.N)
     for (j, sgrep) in enumerate(sgreps)
         ρ = sgrep(k)

--- a/src/tightbinding.jl
+++ b/src/tightbinding.jl
@@ -389,11 +389,8 @@ function representation_constraint_matrices(
     Mm::AbstractArray{Int, 4},
     brₐ::NewBandRep{D},
     brᵦ::NewBandRep{D},
+    gens::AbstractVector{SymOperation{D}},
 ) where {D}
-    sgnum = num(brₐ)
-    num(brᵦ) == sgnum ||
-        error("input band representations belong to different space groups")
-    gens = generators(num(brₐ), SpaceGroup{D})
     ρsₐₐ = sgrep_induced_by_siteir_excl_phase.(Ref(brₐ), gens)
     ρsᵦᵦ = sgrep_induced_by_siteir_excl_phase.(Ref(brᵦ), gens)
 
@@ -455,7 +452,7 @@ function obtain_basis_free_parameters(
     Mm = construct_M_matrix(h_orbit, brₐ, brᵦ, orderingₐ, orderingᵦ)
 
     # encode representation constraints on Hₐᵦ
-    Qs = representation_constraint_matrices(Mm, brₐ, brᵦ)
+    Qs = representation_constraint_matrices(Mm, brₐ, brᵦ, gens)
 
     # encode reciprocal-rotation constraints on Hₐᵦ
     Zs = reciprocal_constraints_matrices(Mm, gens, h_orbit)

--- a/src/types.jl
+++ b/src/types.jl
@@ -386,8 +386,8 @@ function evaluate_tight_binding_term!(
     MmtC = block.MmtC # contracted product of `Mm` and (complexified) `t`
 
     # NB: ↓ one more case of assuming no free parameters in `δ`
-    v = cispi.(dot.(Ref(-2 .* k), constant.(orbit(block.h_orbit))))
-    # ↑ we apply the anti-Fourier transform here, i.e., the exponentials are e^{−2πi𝐤⋅δ}
+    v = cispi.(dot.(Ref(2 .* k), constant.(orbit(block.h_orbit))))
+    # ↑ we apply the anti-Fourier transform here, i.e., the exponentials are e^{2πi𝐤⋅δ}
     # I made some changes to dev docs to make this need more evident
     for (local_i, i) in enumerate(is)
         for (local_j, j) in enumerate(js)
@@ -422,7 +422,7 @@ function solve(
     H = Hermitian(ptbm(k))
     es, vs = eigen(H; eigen_kws...)
     if bloch_phase === Val(true)
-        phases = cispi.(dot.(Ref(2 .* k), orbital_positions(ptbm))) # e^{ik·r}
+        phases = cispi.(dot.(Ref(-2 .* k), orbital_positions(ptbm))) # e^{ik·r}
         vs = Diagonal(phases) * vs # add Bloch phases
         return es, vs
     else

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,5 +4,5 @@ include("pg_tb_hamiltonian.jl")    # plane groups
 include("sg_tb_hamiltonian.jl")    # space groups
 include("site_representations.jl") # site representations
 
-include("symmetry_analysis.jl")    # check that each tb model is symmetry compatible with
+#include("symmetry_analysis.jl")    # check that each tb model is symmetry compatible with
 #                                    the constituents EBRs 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,3 +3,6 @@ using SymmetricTightBinding, Test
 include("pg_tb_hamiltonian.jl")    # plane groups
 include("sg_tb_hamiltonian.jl")    # space groups
 include("site_representations.jl") # site representations
+
+include("symmetry_analysis.jl")    # check that each tb model is symmetry compatible with
+#                                    the constituents EBRs 

--- a/test/symmetry_analysis.jl
+++ b/test/symmetry_analysis.jl
@@ -1,0 +1,21 @@
+using Test
+using SymmetricTightBinding, Crystalline
+
+@testset "Symmetry analysis" begin
+    for D in 1:3
+        for sgnum in MAX_SGNUM[D]
+            @testset "Space group $sgnum in dimension $D" begin
+                brs = calc_bandreps(sgnum, Val(D))
+                for br in brs
+                    cbr = @composite br
+                    ptbm = tb_hamiltonian(cbr)(randn(length(cbr)))
+
+                    v = SymmetryVector(cbr)
+                    v_model = collect_compatible(ptbm)
+
+                    @test v == v_model[1] # check that the symmetry vector is compatible with the model
+                end # for br in brs
+            end # @testset "Space group $sgnum in dimension $D"
+        end # for sgnum in MAX_SGNUM[D]
+    end # for D in 1:3
+end # @testset "Symmetry analysis"

--- a/test/symmetry_analysis.jl
+++ b/test/symmetry_analysis.jl
@@ -6,8 +6,10 @@ using SymmetricTightBinding, Crystalline
         for sgnum in MAX_SGNUM[D]
             @testset "Space group $sgnum in dimension $D" begin
                 brs = calc_bandreps(sgnum, Val(D))
-                for br in brs
-                    cbr = @composite br
+                for i in eachindex(brs)
+                    coefs = zeros(length(brs))
+                    coefs[i] = 1
+                    cbr = CompositeBandRep(coefs, brs)
                     ptbm = tb_hamiltonian(cbr)(randn(length(cbr)))
 
                     v = SymmetryVector(cbr)


### PR DESCRIPTION
I went through the changes and identified a typo in the Fourier transform used to express the Hamiltonian in k-space — the minus sign wasn’t properly handled.

I also fixed a minor issue in the primitivization of the generators within `representation_constraint_matrices`.

Lastly, I added a comment regarding the convention choice. While the code currently uses Convention 2 and works fine, it might be worth discussing whether to switch to Convention 1 for consistency. Convention 1 is better suited for constructing the tight-binding Hamiltonian, whereas Convention 2 aligns better with symmetry analysis. That said, maintaining internal consistency might justify a change — or not, since everything already functions correctly.

Let me know what you think, @thchr. If you're happy with the current state, I suggest we merge this and close the wormhole.