### PR TITLE
Berry curvature & momentum gradients

### DIFF
--- a/src/SymmetricTightBinding.jl
+++ b/src/SymmetricTightBinding.jl
@@ -41,7 +41,11 @@ include("spectrum.jl")
 export spectrum
 include("gradients.jl")
 export gradient_wrt_hopping
+export TightBindingModelHoppingGradient
 export energy_gradient_wrt_hopping
+export gradient_wrt_momentum
+export TightBindingModelMomentumGradient
+include("berry.jl")
 
 # --- Re-exports ------------------------------------------------------------------------- #
 

--- a/src/SymmetricTightBinding.jl
+++ b/src/SymmetricTightBinding.jl
@@ -46,6 +46,7 @@ export energy_gradient_wrt_hopping
 export gradient_wrt_momentum
 export TightBindingModelMomentumGradient
 include("berry.jl")
+export berrycurvature
 
 # --- Re-exports ------------------------------------------------------------------------- #
 

--- a/src/berry.jl
+++ b/src/berry.jl
@@ -1,0 +1,193 @@
+"""
+    berrycurvature(
+        ptbm::ParameterizedTightBindingModel{D},
+        k::ReciprocalPointLike{D},
+        n::Integer,
+        [∇Hs::NTuple{D, Matrix{ComplexF64}}]
+    )  --> Ω
+
+Compute the Berry curvature `Ω` of the `n`th band of the coefficient-parameterized
+tight-binding model `ptbm` at the **k**-point `k`.
+If `D == 3`, `Ω` is a 3-element vector, representing, the three components of the Berry
+curvature pseudovector ``[Ω₁, Ω₂, Ω₃] = [Ω₂₃, Ω₃₁, Ω₁₂]``. 
+If `D == 2`, `Ω` is a scalar, representing the Berry curvature pseudoscalar ``Ω₃ = Ω₁₂``.
+
+The optional `∇Hs` argument is a tuple of work-matrices used to store the momentum gradient
+of the Hamiltonian.
+
+## Implementation
+
+The Berry curvature is evaluated using the Kubo-like or "sum-over-states" formula [^1]:
+```math
+\\Omega_{\\mu, \\nu}^n
+=
+\\sum_{n' \\neq n}
+\\frac{\\langle n |\\partial H/\\partial k_\\mu|n'\\rangle \\langle n'|\\partial H/\\partial k_\\nu|n>
+       - (\\nu \\leftrightarrow \\mu)}
+      {(E_n - E_{n'})^2}
+=
+-2\\mathrm{Im} \\sum_{n' \\neq n}
+\\frac{\\langle n |\\partial H/\\partial k_\\mu|n'\\rangle \\langle n'|\\partial H/\\partial k_\\nu|n>}
+      {(E_n - E_{n'})^2}
+```
+with ``\\Omega_{\\mu, \\nu}^n`` denoting  the Berry curvature tensor component of the `n`th
+band and ``E_n`` denoting the energy of the `n`th band. The Berry curvature pseudovector and
+(antisymmetric) tensor components are related by ``\\Omega_1 = \\Omega_{23}``,
+``\\Omega_2 = \\Omega_{31}``, and ``\\Omega_3 = \\Omega_{12}``.
+
+[1]: Xiao, Chang, & Niu, "Berry phase effects on electronic properties", 
+    [Rev. Mod. Phys. **82**, 1959 (2010)](https://doi.org/10.1103/RevModPhys.82.1959) (see
+    Eq. (1.13)).
+
+## Extended help
+
+As elsewhere in SymmetricTightBinding.jl, this function operates in *reduced* coordinates,
+with the momentum `k = (k₁, k₂, k₃)` indicating coefficients relative to the primitive
+reciprocal lattice vectors ``\\mathbf{b}_i``, i.e., ``\\mathbf{k} = k_1\\mathbf{b}_1 +
+k_2\\mathbf{b}_2 + \\ldots``.
+Crucially, this also implies that returned Berry curvature components are *not* the
+Cartesian components, but components relative to the primitive reciprocal basis.
+
+**In 3D**, this implies that the returned vector `Ω = [Ω₁, Ω₂, Ω₃]` relates to the Berry
+curvature pseudovector ``\\boldsymbol{\\Omega}`` via
+```math
+\\boldsymbol{\\Omega}
+=
+\\Omega_1 \\mathbf{b}_1 + \\Omega_2 \\mathbf{b}_2 + \\Omega_3 \\mathbf{b}_3
+=
+\\Omega_{23} \\mathbf{b}_1 + \\Omega_{31} \\mathbf{b}_2 + \\Omega_{12} \\mathbf{b}_3
+```
+Here, the tensor components ``\\Omega_{12}`` etc. correspond to momentum derivatives in the
+*reduced* coordinates, i.e., the derivatives ``\\partial/\\partial k_{1,2}`` are taken with
+respect to  reduced (dimensionless) coordinates ``k_{1,2}`` rather than Cartesian ones.
+
+As a result, the returned Berry curvature pseudovector components ``[Ω₁, Ω₂, Ω₃]`` are
+related to the Cartesian pseudovector components ``[Ω_x, Ω_y, Ω_z]`` by the primitive
+reciprocal lattice matrix ``\\mathbf{B} = [\\mathbf{b}_1 \\mathbf{b}_2 \\mathbf{b}_3]``:
+```math
+[Ω_x, Ω_y, Ω_z]^{\\text{T}} = \\mathbf{B} [Ω₁, Ω₂, Ω₃]^{\\text{T}}
+```
+
+**In 2D**, the returned Berry curvature is a (pseudo)scalar ``Ω₃ = Ω₁₂``. This value
+represents the component of the Berry curvature 2-form in the reduced coordinate system. It
+is related to the physical pseudoscalar ``\\Omega_{xy}`` by the signed area of the Brillouin
+zone ``A_{\\text{BZ}} = (\\mathbf{b}_1 \\times \\mathbf{b}_2) \\cdot \\hat{\\mathbf{z}}``:
+```math
+\\Omega_z = \\Omega_{xy} = \\Omega_{12} / A_{\\text{BZ}}
+```
+While this distinction is important for interpreting the curvature at an individual
+**k**-point, it can be ignored when calculating the Chern number as an integral over the
+reduced coordinates ``k_{1,2} \\in (-1/2, 1/2]``, since the geometric factors from the
+curvature and the area element ``\\mathrm{d}^2\\mathbf{k}`` cancel out.
+
+### Surface integrals and flux in 3D
+
+When using the returned 3D Berry curvature pseudovector `[Ω₁, Ω₂, Ω₃]` to calculate
+physical observables like the Chern number of a slice or the flux through a surface, it's
+crucial to integrate the correct physical quantity. The assumed goal is always to compute
+a flux integral:
+```math
+\\Phi = \\int_S \\boldsymbol{\\Omega} \\cdot \\,\\mathrm{d}\\mathbf{S}.
+````
+
+While this function returns the components `[Ω₁, Ω₂, Ω₃]` in the reduced basis, the flux
+integrand requires the full dot product between the physical vector ``\\boldsymbol{\\Omega}
+= \\Omega_1 \\mathbf{b}_1 + \\Omega_2 \\mathbf{b}_2 + \\Omega_3 \\mathbf{b}_3`` and the
+physical area element ``\\mathrm{d}\\mathbf{S}``.
+
+The implications of this statement can be appreciated if we consider e.g., calculating the
+Chern number on a planar slice of the BZ, for example the plane spanned by ``\\mathbf{b}_1``
+and ``\\mathbf{b}_2``. The physical area element is ``\\mathrm{d}\\mathbf{S} = 
+(\\mathbf{b}_1 \\times \\mathbf{b}_2) \\, \\mathrm{d}k_1 \\mathrm{d}k_2``, so that the flux
+integrand is:
+
+```math
+\\mathrm{d}\\Phi
+=
+\\boldsymbol{\\Omega} \\cdot d\\mathbf{S}
+=
+(\\Omega_1 \\mathbf{b}_1 + \\Omega_2 \\mathbf{b}_2 + \\Omega_3 \\mathbf{b}_3)
+\\cdot
+(\\mathbf{b}_1 \\times \\mathbf{b}_2) \\, \\mathrm{d}k_1 \\mathrm{d}k_2
+```
+
+By the properties of the triple product, the terms proportional to ``\\Omega_{1,2}`` vanish,
+leaving:
+
+```math
+\\mathrm{d}\\Phi
+=
+\\Omega_3 (\\mathbf{b}_3 \\cdot (\\mathbf{b}_1 \\times \\mathbf{b}_2))
+\\, \\mathrm{d}k_1 \\mathrm{d}k_2
+```
+
+The term `\\mathbf{b}_3 \\cdot (\\mathbf{b}_1 \\times \\mathbf{b}_2)` is the volume of the
+3D Brillouin zone, `V_{\text{BZ}}`.
+
+This shows that the physical flux through the ``(k₁, k₂)`` plane, involves the returned 3D
+component `\\Omega_3``, but scaled by the 3D cell volume `V_BZ`.
+
+For any general surface, the same principle applies: the full dot product must be evaluated,
+which automatically incorporates the required geometric scaling factors.
+"""
+function berrycurvature(
+    ptbm::ParameterizedTightBindingModel{D},
+    k::ReciprocalPointLike{D},
+    n::Integer,
+    ∇Hs::NTuple{D, Matrix{ComplexF64}} = begin
+        ntuple(_->Matrix{ComplexF64}(undef, size(us, 1), size(us, 1)), Val(D))
+    end
+) where {D}
+    Es, us = solve(ptbm, k; bloch_phase=Val(false))
+    Eₙ = Es[n]
+    if count(≈(Eₙ), Es) > 1
+        error(lazy"band $n is degenerate at $k: non-Abelian Berry curvature is not presently handled")
+    end
+    ∇ptbm = gradient_wrt_momentum(ptbm)
+
+    # NB: Below we assume and require H to be Hermitian
+    if D == 2
+        return _berrycurvature_2d(k, ∇ptbm, Es, us, n, ∇Hs)
+    elseif D == 3
+        return _berrycurvature_3d(k, ∇ptbm, Es, us, n, ∇Hs)
+    else
+        error(lazy"Berry curvature is not implemented for $D-dimensional systems")
+    end
+end
+
+function _berrycurvature_2d!(k, ∇ptbm, Es, us, n, ∇Hs::NTuple{2, Matrix{ComplexF64}})
+    components = (1, 2) # k₁ & k₂ components of Hamiltonian gradient
+    ∇Hs = ∇ptbm(k, components, ∇Hs)
+
+    Eₙ = Es[n]
+    uₙ = @view us[:, n]
+    Ω³ = 0.0
+    for m in eachindex(Es)
+        m == n && continue
+        uₘ = @view us[:, m]
+        Eₘ = Es[m]
+        Ω³ -= 2*imag(dot(uₙ, ∇Hs[1], uₘ) * dot(uₘ, ∇Hs[2], uₙ)) / (Eₙ - Eₘ)^2  # Ω³ = Ω₁₂
+    end
+
+    return Ω³
+end
+
+function _berrycurvature_3d!(k, ∇ptbm, Es, us, n, ∇Hs::NTuple{3, Matrix{ComplexF64}})
+    components = (1, 2, 3) # k₁, k₂, & k₃ components of Hamiltonian gradient
+    ∇Hs = ∇ptbm(k, components, ∇Hs)
+
+    Eₙ = Es[n]
+    uₙ = @view us[:, n]
+    Ω¹ = Ω² = Ω³ = 0.0
+    for m in eachindex(Es)
+        m == n && continue
+        uₘ = @view us[:, m]
+        Eₘ = Es[m]
+
+        Ω¹ -= 2*imag(dot(uₙ, ∇Hs[2], uₘ) * dot(uₘ, ∇Hs[3], uₙ)) / (Eₙ - Eₘ)^2  # Ω¹ = Ω₂₃
+        Ω² -= 2*imag(dot(uₙ, ∇Hs[3], uₘ) * dot(uₘ, ∇Hs[1], uₙ)) / (Eₙ - Eₘ)^2  # Ω² = Ω₃₁
+        Ω³ -= 2*imag(dot(uₙ, ∇Hs[1], uₘ) * dot(uₘ, ∇Hs[2], uₙ)) / (Eₙ - Eₘ)^2  # Ω³ = Ω₁₂
+    end
+
+    return SVector{3, Float64}(Ω¹, Ω², Ω³)
+end

--- a/src/gradients.jl
+++ b/src/gradients.jl
@@ -1,4 +1,4 @@
-struct TightBindingModelGradient{D}
+struct TightBindingModelHoppingGradient{D}
    tbm :: TightBindingModel{D}
 end
 
@@ -14,15 +14,18 @@ functor at `k`. I.e., `gradient(tbm)(k)` returns the gradient of the tight-bindi
 Hamiltonian with respect to all hoppping coefficients at momentum `k`. This gradient is a
 vector of matrices.
 """
-gradient_wrt_hopping(tbm::TightBindingModel) = TightBindingModelGradient(tbm)
+gradient_wrt_hopping(tbm::TightBindingModel) = TightBindingModelHoppingGradient(tbm)
 gradient_wrt_hopping(ptbm::ParameterizedTightBindingModel) = gradient_wrt_hopping(ptbm.tbm)
 
-function (tbmg::TightBindingModelGradient{D})(k::ReciprocalPointLike{D}) where D
+function (tbmg::TightBindingModelHoppingGradient{D})(k::ReciprocalPointLike{D}) where D
     map(tbt->tbt(k), tbmg.tbm.terms)
 end
 
 # evaluate just the `i`th component of the coefficient gradient
-function (tbmg::TightBindingModelGradient{D})(k::ReciprocalPointLike{D}, i::Int) where D
+function (tbmg::TightBindingModelHoppingGradient{D})(
+    k::ReciprocalPointLike{D},
+    i::Int
+) where D
     tbmg.tbm[i](k)
 end
 
@@ -98,4 +101,150 @@ function energy_gradient_wrt_hopping(
     end
 
     return eachcol(∇ᶜEs)
+end
+
+# ---------------------------------------------------------------------------------------- #
+struct TightBindingModelMomentumGradient{D}
+   ptbm :: ParameterizedTightBindingModel{D}
+end
+
+"""
+    gradient_wrt_momentum(ptbm :: ParameterizedTightBindingModel)
+
+Return a structure that encodes the gradient of a parameterized tight-binding model `ptbm`
+with respect to its momentum coordinates (in the basis of the primitive reciprocal lattice
+vectors)
+
+To evaluate the gradient at a particular momentum `k`, use the returned structure as a
+functor at `k`. I.e., `gradient_wrt_momentum(ptbm)(k)[i]` returns the `i`th component of the
+momentum derivative of `ptbm` with respect to the momentum at `k`. The return value is a
+`D`-dimensional tuple of matrices (see also [`TightBindingModelMomentumGradient`](@ref)).
+"""
+function gradient_wrt_momentum(ptbm::ParameterizedTightBindingModel{D}) where {D}
+    return TightBindingModelMomentumGradient{D}(ptbm)
+end
+
+"""
+    (∇ptbm::TightBindingModelMomentumGradient{D})(
+        k::ReciprocalPointLike{D},
+        components::NTuple{C, Int},
+        [∇Hs::NTuple{C, Matrix{ComplexF64}}]
+    ) --> ∇Hs
+
+Evaluate components of the momentum gradient `∇ptbm` at momentum `k`, writing into the
+mutated matrix tuple `∇Hs` (automatically initialized if not provided). 
+
+The momentum components are specified by the `components` argument. These specifications are
+assumed relative to the primitive reciprocal lattice vectors ``\\mathbf{b}_i`` (which `k =
+(k₁, k₂, k₃)` is also assumed specified relative to, such that the momentum vector is
+``\\mathbf{k} = k_1 \\mathbf{b}_1 + k_2 \\mathbf{b}_2 + k_3 \\mathbf{b}_3``).
+E.g., for a 3D model with `components = (2, 3)`, the elements of the returned `∇Hs` tuple
+have the interpretation that `∇Hs[1]` is the gradient of the Hamiltonian with respect to
+`k₂`, i.e., ``\\partial H/\\partial k_2``, and `∇Hs[2]` is the gradient with respect to
+`k₃`, ``\\partial H/\\partial k_3``.
+
+## Coordinate transformation
+
+Note that because `k` is specified relative to the primitive reciprocal basis, which is
+generally neither orthogonal nor unit-normalized, the computed gradient is not the gradient
+with respect to the Cartesian components of ``\\mathbf{k}``, nor with respect to the
+coefficients of unit-normalized primitive reciprocal lattice vectors.
+
+One may readily convert to either of these cases by using the chain rule, however. E.g., the
+gradient components ``\\partial H/\\partial k̃_i`` for coordinates ``k̃_i`` relative to a
+unit-normalized reciprocal basis specification of the momentum vector
+``\\mathbf{k} = k̃_1\\hat{\\mathbf{b}}_1 + k̃_2\\hat{\\mathbf{b}}_2 + k̃_3\\hat{\\mathbf{b}}_3``
+are related to the returned components by
+``\\partial H/\\partial k̃_i = |\\mathbf{b}_i|^{-1} \\partial H/\\partial k_i``.
+
+Similarly, the components relative to Cartesian coordinates ``kᶜ_i`` of the momentum vector
+``\\mathbf{k} = kᶜ_1\\hat{\\mathbf{e}}_1 + kᶜ_2\\hat{\\mathbf{e}}_2 + 
+kᶜ_3\\hat{\\mathbf{e}}_3`` can be obtained via ``\\partial H/\\partial kᶜ_i = \\sum_j
+(\\mathbf{B}^{-\\mathrm{T}})_{ij} \\partial H/\\partial k_j``,
+where ``\\mathbf{B} = [\\mathbf{b}_1 \\mathbf{b}_2 \\mathbf{b}_3]`` is a matrix whose
+columns are the primitive reciprocal lattice vectors and ``\\mathbf{B}^{-\\mathrm{T}}`` is
+its inverse transpose.
+"""
+function (∇ptbm::TightBindingModelMomentumGradient{D})(
+    k::ReciprocalPointLike{D},
+    components::NTuple{C, Int},
+    ∇Hs::NTuple{C, Matrix{ComplexF64}} = begin
+        N = ∇ptbm.ptbm.tbm.N
+        ntuple(_ -> zeros(ComplexF64, (N, N)), Val(C))
+    end
+) where {D, C}
+    if length(k) ≠ D
+        error("momentum `k` must be a $D-dimensional vector to match the model dimension")
+    end
+    ptbm = ∇ptbm.ptbm
+    tbm = ptbm.tbm
+    N = tbm.N
+    foreach(∇Hs) do ∇H
+        size(∇H) == (N, N) || _throw_scratch_size_mismatch(∇H, N)
+        fill!(∇H, zero(ComplexF64)) # make sure storage is reset
+    end
+
+    for (tbt, c) in zip(tbm.terms, ptbm.cs) # ↓ modifies `∇Hs` in-place
+        evaluate_tight_binding_momentum_gradient_term!(tbt, k, components, c, ∇Hs)
+    end
+
+    return ∇Hs
+end
+
+"""
+    evaluate_tight_binding_momentum_gradient_term!(
+        tbt::TightBindingTerm,
+        k::ReciprocalPointLike, 
+        components::NTuple{N, Int},
+        [c::Union{Nothing, <:Number} = nothing],
+        [∇Hs::NTuple{N, Matrix{ComplexF64}} = ntuple(zeros(ComplexF64, size(tbt)), N)]
+    )
+
+Evaluate components of the momentum gradient of the tight-binding term `tbt` at
+momentum `k` over momentum, possibly multiplied by a scalar coefficient `c` (unity if
+omitted).
+The components are specified by the `components` tuple: a value of `i` for some `components`
+element indicates the momentum gradient along `k[i]` (`components` values must be in the
+range `1:D`).
+
+The `components[idx]` term is _added_ into the scratch space matrix `∇Hs[idx]`; if `∇Hs`
+is not provided, it is initialized as a suitable tuple of zero matrices of appropriate size.
+The function returns the modified `∇Hs` matrix tuple.
+
+The function is analogous to `evaluate_tight_binding_term!`, but computes momentum
+gradient components rather than the Hamiltonian matrix itself.
+"""
+function evaluate_tight_binding_momentum_gradient_term!(
+    tbt::TightBindingTerm{D},
+    k::ReciprocalPointLike{D},
+    components::NTuple{C, Int},
+    c::Union{Nothing, <:Number} = nothing,
+    ∇Hs::NTuple{C, Matrix{ComplexF64}} = ntuple(_ -> zeros(ComplexF64, size(tbt)), Val(C)),
+) where {D, C}
+    block = tbt.block
+    block_i, block_j = tbt.block_ij
+    is = tbt.axis[Block(block_i)] # global row indices
+    js = tbt.axis[Block(block_j)] # global col indices
+    MmtC = block.MmtC # contracted product of `Mm` and (complexified) `t`
+
+    all(∈(1:D), components) || error(lazy"components must be in 1:$D; got $components")
+
+    # NB: ↓ one more case of assuming no free parameters in `δ`
+    δs = constant.(orbit(block.h_orbit))
+    v_conj = cispi.(-dot.(Ref(2 .* k), δs))
+    for (idx, component) in enumerate(components)
+        ∇H = ∇Hs[idx]
+        δ_mult_v_conj = (- 2im * π) .* getindex.(δs, component) .* v_conj
+        for (local_i, i) in enumerate(is)
+            for (local_j, j) in enumerate(js)
+                ∇Hᵢⱼ = @inbounds dot(δ_mult_v_conj, @view MmtC[:, local_i, local_j])
+                isnothing(c) || (∇Hᵢⱼ *= c) # multiply by coefficient if provided
+                ∇H[i, j] += ∇Hᵢⱼ
+                i == j && continue # don't add diagonal elements twice
+                ∇H[j, i] += tbt.hermiticity == ANTIHERMITIAN ? -conj(∇Hᵢⱼ) : conj(∇Hᵢⱼ)
+            end
+        end
+    end
+
+    return ∇Hs
 end

--- a/src/types.jl
+++ b/src/types.jl
@@ -386,15 +386,17 @@ function evaluate_tight_binding_term!(
     MmtC = block.MmtC # contracted product of `Mm` and (complexified) `t`
 
     # NB: ↓ one more case of assuming no free parameters in `δ`
-    v = cispi.(dot.(Ref(2 .* k), constant.(orbit(block.h_orbit))))
-    # ↑ each term in the hamiltonian is associated to an annihilation/creation operator such
-    # as `aᵢ† aⱼ`. As we use convention 1 for the fourier transform, we have that 
+    v_conj = cispi.(-dot.(Ref(2 .* k), constant.(orbit(block.h_orbit))))
+    # NB: ↑ this is `v` conjugated: we do this because the `dot`-product below conjugates
+    #     its first argument; so by conjugating twice we get the unconjugated result.
+    # NB: ↑ each term in the hamiltonian is associated to an annihilation/creation operator
+    # such as `aᵢ† aⱼ`. As we use convention 1 for the fourier transform, we have that 
     # aᵢ† = e^{-ik·(t + rᵢ)} aₖ†, then each term will be multiplied by the phase 
     # e^{ik·δ}, where δ = R + r\ᵢ - rⱼ, i.e., the hopping vector in the orbit.
     # Note that we store those hopping vectors in the orbit.
     for (local_i, i) in enumerate(is)
         for (local_j, j) in enumerate(js)
-            Hᵢⱼ = @inbounds dot(v, @view MmtC[:, local_i, local_j])
+            Hᵢⱼ = @inbounds dot(v_conj, @view MmtC[:, local_i, local_j])
             isnothing(c) || (Hᵢⱼ *= c) # multiply by coefficient if provided
             H[i, j] += Hᵢⱼ
             i == j && continue # don't add diagonal elements twice


### PR DESCRIPTION
This was a small pet project: it implements single-band (Abelian) Berry curvatures via the sum-over-states like formula.
It's sort of nice conceptually, but maybe not hugely important practically (and probably would be easier done by the usual gradient-free approaches, or by Wilson loops).

There's some conceptual subtleties about how to interpret the components of the Berry curvature when we are in a reduced coordinate setting - I've tried to be quite explicit about these subtleties in the docstrings, just because I feel like I will forget them in the future.

Because the sum-over-states formula needs the momentum gradient of the Hamiltonian, this also adds that: might be nice in the future for e.g., group velocity.

**NOTE:** This also implements a fix for #81 (commit https://github.com/CrystallineOrg/SymmetricTightBinding.jl/commit/f1bfcaddfa36c45bb44ef6c98c4f161bf8b9c4d2), because I would otherwise need to repeat the error in the implementation of the momentum gradient term. But it's a bit iffy to fix it here, because it might influence how we resolve our convention issues. So I suggest we cherry-pick that commit and transfer it to another PR (and hold off on merging this PR until then).