### PR TITLE
Fix #85: force free-parameter orbits to [0, 1) & fix bugged TR-orbit merging

### DIFF
--- a/src/tightbinding.jl
+++ b/src/tightbinding.jl
@@ -85,8 +85,8 @@ end
 """
     maybe_add_hoppings!(h_orbits, δ, qₐ, qᵦ, R, ops) --> Vector{HoppingOrbit{D}}
 
-Checks if a hopping term `δ` is already in the list of representatives. If not, it adds it
-and its symmetry related partners. If it is, it only adds the symmetry related partners.
+Checks if a hopping term `δ` is already in the list of representatives. If not, adds it
+and its symmetry-related partners. If it is, it only adds the symmetry-related partners.
 """
 function maybe_add_hoppings!(
     h_orbits,
@@ -97,7 +97,7 @@ function maybe_add_hoppings!(
     ops::AbstractVector{SymOperation{D}},
 ) where {D}
     δ_idx = findfirst(h_orbits) do h_orbit
-        isapproxin(δ, orbit(h_orbit), nothing, false) # check if δ is in h_orbits
+        isapproxin(δ, orbit(h_orbit), nothing, false) # check if δ is in existing h_orbits
     end
     if isnothing(δ_idx)
         # if it wasn't already in `h_orbits`, we add it and its symmetry-related partners
@@ -200,14 +200,14 @@ function add_reversed_orbits!(h_orbits::Vector{HoppingOrbit{D}}) where {D}
         end
 
         merge_idx = findfirst(
-            h_orbit′ -> isapproxin(δs[1], orbit(h_orbit′), nothing, false),
+            h_orbit′ -> isapproxin(-δs[1], orbit(h_orbit′), nothing, false),
             @view h_orbits[n+1:end]
         )
         if !isnothing(merge_idx)
             # at least one δ has a -δ counterpart in another orbit - we need to merge them
-            # TODO: I will assume that if one δ has a -δ counterpart in another orbit, then all
-            # δs in the orbit have a -δ counterpart in the same orbit, so we merge them
-            n′ = something(idx_merge) + n
+            # NB: We assume that if one δ has a -δ counterpart in another orbit, then all
+            #     δs in the orbit have a -δ counterpart in the same orbit, so we merge them
+            n′ = something(merge_idx) + n
             h_orbit′ = h_orbits[n′]
 
             # merge the orbits

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -232,7 +232,11 @@ function pin_free(br::NewBandRep{D}, αβγ::AbstractVector{<:Real}) where D
     # (which generate the orbit) and potentially also the site group operations for the
     # representative Wyckoff position
     orbit_pin = orbit(siteg_pin)
-    in_primitive_cell = all(rv_pin′ -> all(rᵢ -> 0 ≤ rᵢ < 1, constant(rv_pin′)), orbit_pin)
+    cntr = centering(num(br), D)
+    in_primitive_cell = all(orbit_pin) do rv_pin′
+        rv_pin′_primitive = primitivize(rv_pin′, cntr)
+        all(rᵢ -> 0 ≤ rᵢ < 1, constant(rv_pin′_primitive))
+    end
     if !in_primitive_cell
         siteg_pin, _ = Crystalline.reduce_orbits_and_cosets(siteg_pin)
     end


### PR DESCRIPTION
Two main fixes:

1. In `pin_free`, I hadn't previously accounted for the fact that picking certain alpha-beta-gammas could bring us outside the primitive parallelepiped - the changes to src/utils.jl fixes that.
  This was responsible for the weird-looking orbit in #85.
3. We were missing a minus sign in the path that would potentially merge TR-related orbits - so we never had any merging taking place (in fact, we had a variable name error later, so any attempted merging would have failed). 
   This was responsible for the repeated orbits in #85.

Should be good to merge pretty quickly, but have a look @AntonioMoralesPerez.