### PR TITLE
Fix #74: `Mm` matrix should include time-reversed hopping directions

### DIFF
--- a/test/symmetry-breaking.jl
+++ b/test/symmetry-breaking.jl
@@ -46,7 +46,7 @@ using Crystalline
         cbr = @composite brs[1] + brs[end] #  (1h|A) + (1a|B₂) (2 bands)
         tbm = tb_hamiltonian(cbr, [[0,0,0],])
 
-        @test length(subduced_complement(tbm, 3)) == 1
+        @test length(subduced_complement(tbm, 3)) == 2
     end
 
     @testset "broken 3D example" begin


### PR DESCRIPTION
This is an attempt at fixing #74. On the face of things, it fixes both the cases I identified in the issue - but, the fix is subtle and has caused me to question whether we really do the right thing more generally in this case.

To explain the issue, let me rephrase #74 somewhat, now that I have a better understanding of it:

1. The problem class occurs only when we try to construct a model for two (or more) EBRs, with _different_ Wyckoff positions (say, associated with `br1` (Wyckoff position **q**) and `br2` (Wyckoff position **w**)).
   In this setting, because time-reversal / hermicity requires that we have both hopping directions, we end up in a situation where reversing a hopping term from **q** to **w**, gives us a hop from **w** to **q**.
   But, we originally assumed that a tight-binding block "`H[br1, br2]`" would only involve hops from **q** _to_ **w**, not the other way around. So, we didn't check for this in `construct_M_matrix`. But, we are actually returning such hops in `obtain_symmetry_related_hoppings(..., br1, br2)`, and it is this function that implicitly decides the interpretation of the columns of `Mm`.

2. My fix here is to just also check for time-reversed hoppings with the "reversed" interpretation and index position. But it's ... very opaque with the current indexing etc.

My worry - which I've tried to summary in a FIXME comment - is that we don't really carry this through all the way. Or at least, I can't convince myself that we do. The problem, at its root, is that we haven't formalized this bit very clearly.

Please have a look at this @AntonioMoralesPerez and give it some thought before our next meeting so we can discuss this as well as #89.