### PR TITLE
Fix 74 and timereversal

### DIFF
--- a/src/tightbinding.jl
+++ b/src/tightbinding.jl
@@ -78,7 +78,7 @@ function obtain_symmetry_related_hoppings(
 
     # since the code is always considering hermiticity or anti-hermiticity, this terms will
     # always be added if the term is a diagonal block or if timereversal is imposed
-    if diagonal_block || timereversal
+    if diagonal_block
         # we only need to do this if we have time-reversal symmetry or if we are 
         # constructing a diagonal block (which must be Hermitian or anti-Hermitian)
         add_reversed_orbits!(h_orbits)

--- a/src/timereversal.jl
+++ b/src/timereversal.jl
@@ -26,7 +26,7 @@
 
 # we are going to assume for now that the transform as real irreps of the site-symmetry 
 # group. TRS can be understood as a spacial symmetry when acting on the Hamiltonian:
-# `D(𝒯)H(k)D(𝒯)⁻¹ = H(𝒯k) -> Γ(𝒯)H*(k)Γ(𝒯)⁻¹ = H(-k)`, where `D` is the whole 
+# `D(𝒯)H(k)D(𝒯)† = H(𝒯k) -> Γ(𝒯)H*(k)Γ(𝒯)† = H(-k)`, where `D` is the whole 
 # operator and `Γ` is only the unitary part, so `D(𝒯) = Γ(𝒯)𝒯`
 # If the site-symmetry irrep is real, `Γ(𝒯) = I -> H*(k) = H(-k)`.
 
@@ -36,13 +36,22 @@
 # we have that `Hᵢⱼ(k) = vᵀ(k) Mᵢⱼ t`. Then, we need to make the following change:
 # `Hᵢⱼ(k) = vᵀ(k) [Mᵢⱼ Mᵢⱼ] [real(t); imag(t)]`
 
-# Then applying TRS will be:
+# Then, applying TRS will be:
 
 # 1. `H(-k) = vᵀ(-k) [Mᵢⱼ Mᵢⱼ] [real(t); imag(t)] = (Pv)ᵀ(k) [Mᵢⱼ Mᵢⱼ] 
-# [real(t); imag(t)] = vᵀ(k) [Pᵀ Mᵢⱼ Pᵀ Mᵢⱼ] [real(t); imag(t)]`
+# [real(t); imag(t)]`
 
 # 2. `H*(k) = (v*)ᵀ(k) [Mᵢⱼ Mᵢⱼ] [real(t); -imag(t) -imag(im*t)] = (Pv)ᵀ(k) 
-# [Mᵢⱼ -Mᵢⱼ] [real(t); imag(t)] = vᵀ(k) [Pᵀ Mᵢⱼ -Pᵀ Mᵢⱼ] [real(t); imag(t)]`
+# [Mᵢⱼ -Mᵢⱼ] [real(t); imag(t)]`
+
+# Imposing the condition `H(-k) = H*(k)` we get:
+# `(Pv)ᵀ(k) [Mᵢⱼ Mᵢⱼ] [real(t); imag(t)] = (Pv)ᵀ(k) [Mᵢⱼ -Mᵢⱼ] [real(t); imag(t)]`
+# which can be rewritten as:
+# `(Pv)ᵀ(k) [0 2Mᵢⱼ] [real(t); imag(t)] = 0`
+
+# NOTE: This way of casting the problem allows us to not use the "extended" 𝐯-vector with 
+# the reversed hopping in non-diagonal blocks, which could potentially enforce extra 
+# symmetries in the system.
 
 """
     obtain_basis_free_parameters_TRS(
@@ -75,16 +84,12 @@ function obtain_basis_free_parameters_TRS(
     # Step 1: compute the Z tensor, encoding time-reversal constraints on H for the k-space
     # part. This is done by `Hᵢⱼ(-k) = vᵀ(-k) [Mᵢⱼ Mᵢⱼ] [tᴿ; tᴵ]`
     # `= (Pv)ᵀ(k) [Mᵢⱼ Mᵢⱼ] [tᴿ; tᴵ]`
-    # `= vᵀ(k) [Pᵀ Mᵢⱼ Pᵀ Mᵢⱼ] [tᴿ; tᴵ]`
-    Z = reciprocal_constraints_trs(Mm, h_orbit)
-    # QUESTION: in the above assume that we have ±δ in v. Is this true? why? it is ok
-    #           physically and in here we will see if they are equal or not.
+    Z = [Mm Mm]
 
     # Step 2: compute the Q tensor, encoding time-reversal constraints on H for the free-
     # parameter part. This is done by `H*(k) = (v*)ᵀ(k) [Mᵢⱼ Mᵢⱼ] [tᴿ; -itᴵ]`
     # `= (Pv)ᵀ(k) [Mᵢⱼ -Mᵢⱼ] [tᴿ; tᴵ]`
-    # `= vᵀ(k) [Pᵀ Mᵢⱼ -Pᵀ Mᵢⱼ] [tᴿ; tᴵ]`
-    Q = representation_constraint_trs(Mm, h_orbit)
+    Q = [Mm -Mm]
 
     # Step 3: build an constraint matrix acting on the doubled hopping coefficient vector
     # `[tᴿ; itᴵ]` associated with `h_orbit`; each row is a constraint
@@ -92,53 +97,4 @@ function obtain_basis_free_parameters_TRS(
     tₐᵦ_basis_matrix = nullspace(constraints; atol = NULLSPACE_ATOL_DEFAULT)
 
     return tₐᵦ_basis_matrix
-end
-
-"""
-    reciprocal_constraints_trs(Mm::AbstractArray{Int,4}, h_orbit::HoppingOrbit{D}) 
-    --> Array{ComplexF64,4}
-
-Time reversal symmetry action on reciprocal space. It is given by the association 
-`k -> -k => H(k) -> H(-k)`.
-"""
-function reciprocal_constraints_trs(
-    Mm::AbstractArray{Int, 4},
-    h_orbit::HoppingOrbit{D},
-) where {D}
-    Z = similar(Mm)
-    opI = inversion(Val(D)) # inversion operation
-    Pᵀ =
-        transpose(_permute_symmetry_related_hoppings_under_symmetry_operation(h_orbit, opI))
-    for s in axes(Mm, 3)
-        for t in axes(Mm, 4) # vᵀ Ρᵀ Mₛₜ t => vₗ Ρᵀₗᵢ Mᵢⱼₛₜ tⱼ = vₗ Pᵢₗ Mᵢⱼₛₜ tⱼ
-            Z[:, :, s, t] .= Pᵀ * @view Mm[:, :, s, t] # Pᵀ M⁽ˢᵗ⁾
-        end
-    end
-    return [Z Z]
-end
-
-"""
-    representation_constraint_trs(Mm::AbstractArray{Int,4}, h_orbit::HoppingOrbit{D})
-    --> Array{ComplexF64,4}
-
-Time reversal symmetry action on the Hamiltonian. It is given by the association δ -> -δ and 
-the complex conjugation in the free-parameter part:
-``tⱼ -> tⱼ* ⇒ [tⱼᴿ, itⱼᴵ] -> [tⱼᴿ, -itⱼᴵ] ⇒ H(k) -> H*(k)``.
-"""
-function representation_constraint_trs(
-    Mm::AbstractArray{<:Number, 4},
-    h_orbit::HoppingOrbit{D},
-) where {D}
-    Q = zeros(Int, size(Mm))
-    opI = inversion(Val(D)) # inversion operation
-    # TODO: We are doing exactly the same here as in `representation_constraint_trs`: the
-    #       only difference is we return `[Q -Q]` at the end instead of `[Z Z]` (but Q = Z).
-    Pᵀ =
-        transpose(_permute_symmetry_related_hoppings_under_symmetry_operation(h_orbit, opI))
-    for s in axes(Mm, 3)
-        for t in axes(Mm, 4) # vᵀ Ρᵀ Mₛₜ t => vₗ Ρᵀₗᵢ Mᵢⱼₛₜ tⱼ = vₗ Pᵢₗ Mᵢⱼₛₜ tⱼ
-            Q[:, :, s, t] .= Pᵀ * @view Mm[:, :, s, t] # Pᵀ M⁽ˢᵗ⁾
-        end
-    end
-    return [Q -Q]
 end


### PR DESCRIPTION
This is a PR that takes the lead of PR #91 to fix #74. Let me summarize why I made these changes and why it also solves #74 more pleasantly.

As you pointed out in #91, the issue comes when we consider terms involving two EBRs with _different_ Wyckoff positions. Let me call them `br1`, with Wyckoff position 𝐪, and `br2`, with Wyckoff position 𝐰. In this case, (anti-)hermiticity doesn't play a role since we are in an off-diagonal term and its (anti-)hermitian partner goes in another block. Then, because of time reversal, we claimed that we needed to add a reversed hopping. However, now I don't think that is completely right. I agree we needed the trick of translating the change `𝐤 → -𝐤` into `δ → -δ`, but we should not consider that reversed hopping when building the Hamiltonian, since that potentially adds extra terms, as you were seeing in your example.

I made a change on how we treat time reversal in the code, so we do not need the former trick, and then, we are able to not add the reverse hopping because of time reversal. In that way, we do not have extra fictional terms coming from unnecessary reverse hopping.

Additionally, since now only reverse hoppings are added when (anti-)hermiticity is important, i.e., in diagonal blocks, we erase your concern on the indexing, since now not only 𝐪 and 𝐰 coincide but also the site-symmetry irreps.

I think this is the proper way to treat time reversal and also fix the issue of zero blocks, but also prevents possible issues due to potential extra symmetries present in the model.

I know it is a lot of changes and information, and summarizing doesn't help; that's why I made several comments in the code and also made a small example answering your FIXME comment @thchr. Moreover, I will send you a handwritten example of plane group 13 that might be easier to follow.

Notice that this doesn't solve issue #89, since that problem appears on single band reps, which will correspond to diagonal terms. I will now focus on #89 and try to solve it or at least clarify it.