### PR TITLE
Correct sign hoppings

### DIFF
--- a/docs/src/devdocs/trs_notes.md
+++ b/docs/src/devdocs/trs_notes.md
@@ -37,8 +37,9 @@ where $\mathcal{N}$ is a unitary subgroup of index 2 (normal subgroup), and
 $\mathcal{A} \notin \mathcal{N}$ an anti-unitary element of $\mathcal{M}$.
 
 > [!NOTE]
-> For our purposes, $\mathcal{N}$ is the space group and $\mathcal{A}$ is TRS,
-> since we are interested in grey groups.
+> This formalism is quite general and can be applied to all kind of magnetic
+> space groups. However, since we are interested in space groups, $\mathcal{N}$
+> can be identified as the space group and $\mathcal{A}$ as TRS.
 
 > [!IMPORTANT] 
 > **Notation:** We denote elements of $\mathcal{N}$ by $R$, $S$, $T$, etc., and 
@@ -175,8 +176,10 @@ $$
 > we want to include fermionic TRS we will need to add a minus sign, consequently.
 
 > [!NOTE]
-> Since we are interested only in a generating set of $\mathcal{M}$, it suffices
-> to consider $\Theta$ alone rather than a general $\mathcal{B} \in \Theta\mathcal{G}$.
+> In the implementation, we only consider $\Theta$ to include new constraints.
+> This can be justified by the fact that grey groups can be decomposed as 
+> $\mathcal{M} = \mathcal{G} \otimes \{E, \Theta\}$.
+> **Important**: this is an assumption that must be verified.
 
 #### Three scenarios for the co-representation
 
@@ -371,6 +374,8 @@ where $h \in G_\mathbf{q}$ and $t_{αβ} \equiv g\mathbf{q}_α -
 
 > [!NOTE]
 > This follows from the coset decomposition; see, e.g., Bradlyn *et al.* [1].
+> Note that this reference does not include an explicit proof of the above equation.
+> **TODO**: Consider adding a proof as an appendix in the future.
 
 Taking all of this into consideration, we can deduce how our basis set will 
 transform under the action of every $g \in G$:
@@ -645,9 +650,11 @@ $$
 Then $Θ φ_{I,\mathbf{k}}$ yields the same representation as $φ_{I,\mathbf{k}} $ 
 so they can be chosen such that $φ_{I,\mathbf{k}} = Θ φ_{I,\mathbf{k}}$
 
-> [!CAUTION]
-> This argument assumes that Schur's lemma applies, which requires the
-> representation to be irreducible.
+> [!WARNING]
+> This argument assumes that if two representations are identical, their bases
+> can be chosen to be identical.
+> **TODO**: Verify whether this holds in general. Schur's lemma may provide
+> a useful framework for this.
 
 ## Appendix A
 

--- a/docs/src/devdocs/trs_notes.md
+++ b/docs/src/devdocs/trs_notes.md
@@ -7,50 +7,6 @@ transformation into the formalism that can be identified with TRS. Then, we
 specialize to TRS and, particularly, to bosonic TRS:
 $\Theta² = +\mathbb{I}$.
 
-## How TRS Acts in the Presence of Another Spatial Symmetry
-
-A key question is how TRS interacts with other spatial symmetries. In general,
-and in particular for this section, the TRS operator $\Theta$ commutes with
-any element $R$ of a point group or a space group, i.e.,
-
-$$
-R \Theta = \Theta R 
-$$
-
-and therefore have *real representations*. This is important for our
-setting. Here is a sketch of the proof:
-
----
-
-We write the system wave function as 
-
-$$
-\psi(\mathbf{r}) = \psi_\mathcal{R}(\mathbf{r}) + i \psi_\mathcal{I}(\mathbf{r})
-$$
-
-where $\psi_\mathcal{R}(\mathbf{r})$ and $\psi_\mathcal{I}(\mathbf{r})$ are 
-real functions. Operating with $\Theta R$ and later with $R \Theta$, we 
-obtain
-
-$$
-\Theta R \psi(\mathbf{r}) = \Theta \psi(R⁻¹\mathbf{r}) = 
-(\psi_\mathcal{R}(R⁻¹\mathbf{r}) + i \psi_\mathcal{I}(R⁻¹\mathbf{r}))^* \\
-
-R \Theta \psi(\mathbf{r}) = \Theta \psi(R⁻¹\mathbf{r}) = 
-\psi_\mathcal{R}(R⁻¹\mathbf{r}) - i \psi_\mathcal{I}(R⁻¹\mathbf{r})
-$$
-
-The two results are equal since $R$ is orthogonal, which implies that the
-representations are also real.
-
----
-
-> [!NOTE]
-> This argument is only valid for spinless systems.
-
-However, this is a simple case involving state kets. What happens when we
-consider the action of TRS on a more abstract representation basis set?
-
 ## Time-Reversed Representation: Theory of Corepresentations
 
 We start by considering the combined action of $\Theta$ with another linear

--- a/src/types.jl
+++ b/src/types.jl
@@ -99,14 +99,14 @@ struct TightBindingBlock{D} <: AbstractMatrix{TightBindingElementString}
 end
 Base.size(tbb::TightBindingBlock) = (size(tbb.Mm, 3), size(tbb.Mm, 4))
 function TightBindingBlock{D}(
-    br1, 
-    br2, 
-    ordering1, 
-    ordering2, 
-    h_orbit, 
-    Mm, 
-    t, 
-    diagonal_block
+    br1,
+    br2,
+    ordering1,
+    ordering2,
+    h_orbit,
+    Mm,
+    t,
+    diagonal_block,
 ) where D
     Nᵗ = length(t) ÷ 2
     tC = complex.((@view t[1:Nᵗ]), (@view t[Nᵗ+1:end]))
@@ -115,15 +115,15 @@ function TightBindingBlock{D}(
         MmtC[:, i, j] = (@view Mm[:, :, i, j]) * tC
     end
     tbb = TightBindingBlock{D}(
-        br1, 
-        br2, 
-        ordering1, 
-        ordering2, 
-        h_orbit, 
-        Mm, 
-        t, 
-        MmtC, 
-        diagonal_block
+        br1,
+        br2,
+        ordering1,
+        ordering2,
+        h_orbit,
+        Mm,
+        t,
+        MmtC,
+        diagonal_block,
     )
     return tbb
 end
@@ -416,13 +416,13 @@ function evaluate_tight_binding_term!(
     MmtC = block.MmtC # contracted product of `Mm` and (complexified) `t`
 
     # NB: ↓ one more case of assuming no free parameters in `δ`
-    v_conj = cispi.(dot.(Ref(-2 .* k), constant.(orbit(block.h_orbit))))
+    v_conj = cispi.(dot.(Ref(2 .* k), constant.(orbit(block.h_orbit))))
     # NB: ↑ this is `v` conjugated: we do this because the `dot`-product below conjugates
     #     its first argument; so by conjugating twice we get the unconjugated result.
     # NB: ↑ each term in the Hamiltonian is associated to an annihilation+creation operator
     #     pair `aᵢ† aⱼ`. Since we use Convention 1 for the Fourier transform, we have
     #     aᵢ† = ∑ₖ e^{-ik·(tᵢ + rᵢ)} aₖ†, such that each term will be multiplied by a phase 
-    #     e^{ik·δᵢⱼ} with δᵢⱼ ≡ Rᵢⱼ + rᵢ - rⱼ, i.e., the hopping vector in the orbit; this
+    #     e^{-ik·δᵢⱼ} with δᵢⱼ ≡ Rᵢⱼ + rᵢ - rⱼ, i.e., the hopping vector in the orbit; this
     #     is what `orbit(block.h_orbit)` gives us above
     for (local_i, i) in enumerate(is)
         for (local_j, j) in enumerate(js)


### PR DESCRIPTION
I made this PR correcting the sign of the exponential we discussed.

After thinking about it, I believed we may need some changes also on how `h_orbit` of each tight-binding block is computed. I need to go back to the other project, but I wanted to see if this - as it is - passes the tests. I believe it will not.

Later today or during the weekend I will try to debug more deeply the function `obtain_symmetry_related_hoppings`.

X-ref #89.