### PR TITLE
fix: drop GeometryBasics type piracy, add ≥0.5.11 lower bound

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,6 +11,7 @@ RowEchelon = "af85af4c-bcd5-5d23-b03a-a909639aa875"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [weakdeps]
+GeometryBasics = "5c1252a2-5f33-56bf-86c9-59e7332b4326"
 Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
 Optim = "429524aa-4258-5aef-a3af-852621145aeb"
 
@@ -21,6 +22,7 @@ SymmetricTightBindingOptimExt = "Optim"
 [compat]
 BlockArrays = "1.6.3"
 Crystalline = "0.6.24"
+GeometryBasics = "0.5.11"
 LinearAlgebra = "1.11.0"
 Makie = "0.24.2"
 Optim = "1"
@@ -29,5 +31,6 @@ StaticArrays = "1.9.15"
 julia = "1.12"
 
 [extras]
+GeometryBasics = "5c1252a2-5f33-56bf-86c9-59e7332b4326"
 Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
 Optim = "429524aa-4258-5aef-a3af-852621145aeb"

--- a/ext/SymmetricTightBindingMakieExt.jl
+++ b/ext/SymmetricTightBindingMakieExt.jl
@@ -10,16 +10,6 @@ using Makie
 
 ## --------------------------------------------------------------------------------------- #
 
-# This method is missing in GeometryBasics (see GeometryBasics.jl PR#277); pirate-patch
-# TODO: remove eventually, if above-noted PR is merged and released
-function Makie.GeometryBasics.coordinates(rect::Rect{1, T}) where T
-    w = rect.widths
-    o = rect.origin
-    return [Point{1,T}(o[1]), Point{1,T}(o[1]+w[1])]
-end
-
-## --------------------------------------------------------------------------------------- #
-
 const MaybeCoefficient = Union{Nothing, <:AbstractVector{<:Number}}
 const default_context_attributes = Attributes(;
     include = true, color = :gray75, linecolor = :gray80, linewidth = 1.25, limits = nothing


### PR DESCRIPTION
Fixes #110.

> **Note:** This branch is based on `hopping-sign-flip`, **not** `main`, to avoid `CLAUDE.md` merge conflicts. Please merge that one first.

## What

`SymmetricTightBindingMakieExt` defined `Makie.GeometryBasics.coordinates(::Rect{1,T})` to work around a method that was missing in GeometryBasics ≤ 0.5.10. That method now exists upstream (GeometryBasics PR#277), so on GeometryBasics ≥ 0.5.11 our definition *overwrites* it, which is a hard precompile error on Julia 1.12:

> Method overwriting is not permitted during Module precompilation

This made the extension fail to load (hopping-orbit plots, `plot(tbm, Rs)`) on current GeometryBasics. Band-structure plotting via Brillouin.jl's Makie extension was unaffected.

## Changes

- Remove the pirate-patch from `ext/SymmetricTightBindingMakieExt.jl`.
- Declare `GeometryBasics` in `Project.toml` under `[weakdeps]`, `[compat] = "0.5.11"`, and `[extras]`. It is not an extension trigger; the entries exist only to carry the lower bound, which Pkg enforces since GeometryBasics is always pulled in via Makie.
- Mark known-issue `#6` resolved in `CLAUDE.md`.