### PR TITLE
Fix `subduced_complement` for shared-Wyckoff composites and centered lattices

### DIFF
--- a/src/symmetry_breaking.jl
+++ b/src/symmetry_breaking.jl
@@ -104,6 +104,16 @@ function subduced_complement(tbm::TightBindingModel{D}, sgnumᴴ::Int; kws...) w
     return subduced_complement(tbm, gensᴴ; kws...)
 end
 
+"""
+    subduced_complement(tbm::TightBindingModel{D}, gensᴴ::AbstractVector{SymOperation{D}};
+                        timereversal)                       --> TightBindingModel{D}
+
+Variant of [`subduced_complement`](@ref) taking the generators `gensᴴ` of the subgroup ``H``
+directly, rather than its space group number.
+
+The generators must be given in the *conventional* setting of the original group ``G``
+(i.e., in the setting of `tbm`); they are converted internally to the primitive setting.
+"""
 function subduced_complement(
     tbm::TightBindingModel{D, S},
     gensᴴ::AbstractVector{SymOperation{D}};
@@ -115,6 +125,14 @@ function subduced_complement(
             "requested subgroup `timereversal = true`, but original model was built without time-reversal present; input for H must maintain or reduce symmetry",
         )
     end
+
+    # the constraint machinery in `_obtain_basis_free_parameters` works in the primitive
+    # setting (cf. `obtain_basis_free_parameters`), but `gensᴴ` is given in the conventional
+    # setting of G: convert, lest we compare conventional-setting operations against the
+    # primitivized site symmetry groups of `sgrep_induced_by_siteir` (which finds no
+    # matching coset and errors out)
+    cntr = centering(num(tbm.cbr), D)
+    gensᴴ′ = cntr ∈ ('P', 'p') ? gensᴴ : primitivize.(gensᴴ, cntr)
 
     # we need to go through the terms of `tbm` in "groups of the same orbit" - each orbit
     # will have some coefficient basis, and it is this basis we need to compare. So first,
@@ -148,7 +166,7 @@ function subduced_complement(
             tbb.ordering1,
             tbb.ordering2,
             tbb.Mm,
-            gensᴴ,
+            gensᴴ′,
             timereversal,
             tbt.block_ij[1] == tbt.block_ij[2], #= .diagonal_block =#
             S,                                  #= hermiticity =#

--- a/src/symmetry_breaking.jl
+++ b/src/symmetry_breaking.jl
@@ -101,20 +101,26 @@ function subduced_complement(tbm::TightBindingModel{D}, sgnumᴴ::Int; kws...) w
     _gensᴴ = generators(sgnumᴴ, SpaceGroup{D}) # in H setting
     gensᴴ = transform.(_gensᴴ, Ref(Pᴴ²ᴳ), Ref(pᴴ²ᴳ))
 
-    return subduced_complement(tbm, gensᴴ; kws...)
+    return _subduced_complement(tbm, gensᴴ; kws...)
 end
 
 """
-    subduced_complement(tbm::TightBindingModel{D}, gensᴴ::AbstractVector{SymOperation{D}};
-                        timereversal)                       --> TightBindingModel{D}
+    _subduced_complement(tbm::TightBindingModel{D}, gensᴴ::AbstractVector{SymOperation{D}};
+                         timereversal)                      --> TightBindingModel{D}
 
-Variant of [`subduced_complement`](@ref) taking the generators `gensᴴ` of the subgroup ``H``
-directly, rather than its space group number.
+Implementation of [`subduced_complement`](@ref), taking the generators `gensᴴ` of the
+subgroup ``H`` rather than its space group number.
 
-The generators must be given in the *conventional* setting of the original group ``G``
-(i.e., in the setting of `tbm`); they are converted internally to the primitive setting.
+`gensᴴ` must be given in the *conventional* setting of the original group ``G`` (i.e., in
+the setting of `tbm`); they are converted to the primitive setting internally. This is why
+the method is not part of the public API: obtaining `gensᴴ` in G's setting requires the
+transformation dance of the `sgnumᴴ` method, which is not reasonable to ask of a caller.
+
+!!! warning
+    This function is an internal helper function for `subduced_complement` and is not part
+    of the public API.
 """
-function subduced_complement(
+function _subduced_complement(
     tbm::TightBindingModel{D, S},
     gensᴴ::AbstractVector{SymOperation{D}};
     timereversal::Bool = first(tbm.cbr.brs).timereversal, # ← whether H has time-reversal
@@ -126,12 +132,17 @@ function subduced_complement(
         )
     end
 
+    sgnumᴳ = num(tbm.cbr)
+    @assert _issubgroup(gensᴴ, sgnumᴳ) LazyString(
+        "`gensᴴ` must generate a subgroup of G (⋕", sgnumᴳ, ") and be given in G's \
+         conventional setting, but ", gensᴴ, " is not a subset of the operations of G")
+
     # the constraint machinery in `_obtain_basis_free_parameters` works in the primitive
     # setting (cf. `obtain_basis_free_parameters`), but `gensᴴ` is given in the conventional
     # setting of G: convert, lest we compare conventional-setting operations against the
     # primitivized site symmetry groups of `sgrep_induced_by_siteir` (which finds no
     # matching coset and errors out)
-    cntr = centering(num(tbm.cbr), D)
+    cntr = centering(sgnumᴳ, D)
     gensᴴ′ = cntr ∈ ('P', 'p') ? gensᴴ : primitivize.(gensᴴ, cntr)
 
     # we need to go through the terms of `tbm` in groups that share a coefficient basis -
@@ -251,6 +262,24 @@ function subduced_complement(
         end
     end
     return TightBindingModel{D, S}(complement_tbs, tbm.cbr, tbm.positions, tbm.N)
+end
+
+"""
+    _issubgroup(gensᴴ::AbstractVector{SymOperation{D}}, sgnumᴳ::Int)  --> Bool
+
+Return whether every operation of `gensᴴ` is an operation of the space group `sgnumᴳ` (up to
+lattice translations), i.e., whether `gensᴴ` generates a subgroup ``H ≤ G``.
+
+`gensᴴ` is assumed given in the conventional setting of ``G``.
+
+!!! warning
+    This function is an internal helper function for `subduced_complement` and is not part
+    of the public API.
+"""
+function _issubgroup(gensᴴ::AbstractVector{SymOperation{D}}, sgnumᴳ::Int) where {D}
+    cntr = centering(sgnumᴳ, D)
+    opsᴳ = spacegroup(sgnumᴳ, Val(D))
+    return all(opᴴ -> any(opᴳ -> isapprox(opᴳ, opᴴ, cntr), opsᴳ), gensᴴ)
 end
 
 """

--- a/src/symmetry_breaking.jl
+++ b/src/symmetry_breaking.jl
@@ -134,23 +134,9 @@ function subduced_complement(
     cntr = centering(num(tbm.cbr), D)
     gensᴴ′ = cntr ∈ ('P', 'p') ? gensᴴ : primitivize.(gensᴴ, cntr)
 
-    # we need to go through the terms of `tbm` in "groups of the same orbit" - each orbit
-    # will have some coefficient basis, and it is this basis we need to compare. So first,
-    # we figure out the groupings into these orbits by just looking at `tbt.block.h_orbit`
-    grouped_orbits_idxs = UnitRange{Int}[]
-    current_h_orbit = first(tbm.terms).block.h_orbit
-    i₁ = 1
-    i₂ = 0
-    for tbt in tbm.terms
-        if current_h_orbit == tbt.block.h_orbit
-            i₂ += 1
-        else
-            push!(grouped_orbits_idxs, i₁:i₂)
-            current_h_orbit = tbt.block.h_orbit
-            i₁ = i₂ = i₂ + 1
-        end
-    end
-    i₂ == length(tbm.terms) && push!(grouped_orbits_idxs, i₁:i₂)
+    # we need to go through the terms of `tbm` in groups that share a coefficient basis -
+    # it is this basis we need to compare. So first, we figure out those groupings
+    grouped_orbits_idxs = _group_terms_by_block_and_orbit(tbm)
 
     # now we can compute a new coefficient basis in H and compare with our original basis,
     # progressing "group by group"
@@ -174,10 +160,20 @@ function subduced_complement(
         # check output dimensions
         if length(tₐᵦ_basis_reimᴴ_vs) < length(idxs)
             error(
-                "unexpectedly found lower-dimensional basis space for model in subduced \
-                 group; unexpected and unhandled - make sure the generators are a subset \
-                 of the original generators (i.e., that fewer constraints apply than \
-                 originally)",
+                LazyString(
+                    "unexpectedly found lower-dimensional basis space for model in \
+                     subduced group (dim ",
+                    length(tₐᵦ_basis_reimᴴ_vs),
+                    " < ",
+                    length(idxs),
+                    " terms, for block ",
+                    tbt.block_ij,
+                    " & orbit ",
+                    representative(tbb.h_orbit),
+                    "); unexpected and unhandled - make sure the generators are a subset \
+                     of the original generators (i.e., that fewer constraints apply than \
+                     originally)",
+                ),
             )
         elseif length(tₐᵦ_basis_reimᴴ_vs) == length(idxs)
             continue # basis must then be unchanged; nothing to add for this index group
@@ -217,6 +213,10 @@ function subduced_complement(
                         Nᴴ,
                         " σs = ",
                         σs,
+                        ", for block ",
+                        tbt.block_ij,
+                        " & orbit ",
+                        representative(tbb.h_orbit),
                         ")",
                     ),
                 )
@@ -251,4 +251,34 @@ function subduced_complement(
         end
     end
     return TightBindingModel{D, S}(complement_tbs, tbm.cbr, tbm.positions, tbm.N)
+end
+
+"""
+    _group_terms_by_block_and_orbit(tbm::TightBindingModel{D})  --> Vector{Vector{Int}}
+
+Group the indices of the terms of `tbm` that share a coefficient basis, i.e., that share
+both a block (`block_ij`) and a hopping orbit (`h_orbit`). Groups are returned in order of
+first appearance.
+
+Note that it is not sufficient to group by `h_orbit` alone: distinct blocks whose band
+representations sit at the same Wyckoff position have equal (`==`) hopping orbits, since
+`HoppingOrbit` compares structurally. Nor can the terms of a group be assumed contiguous:
+models may be assembled by `vcat` or by indexing into an existing model.
+"""
+function _group_terms_by_block_and_orbit(tbm::TightBindingModel{D}) where {D}
+    idxs_groups = Vector{Int}[]
+    group_keys = Tuple{NTuple{2, Int}, HoppingOrbit{D}}[]
+    for (i, tbt) in enumerate(tbm.terms)
+        block_ij, h_orbit = tbt.block_ij, tbt.block.h_orbit
+        j = findfirst(group_keys) do (block_ij′, h_orbit′)
+            block_ij′ == block_ij && h_orbit′ == h_orbit
+        end
+        if isnothing(j)
+            push!(group_keys, (block_ij, h_orbit))
+            push!(idxs_groups, [i])
+        else
+            push!(idxs_groups[j], i)
+        end
+    end
+    return idxs_groups
 end

--- a/test/symmetry-breaking.jl
+++ b/test/symmetry-breaking.jl
@@ -1,5 +1,6 @@
 using Test
 using SymmetricTightBinding
+using SymmetricTightBinding: _group_terms_by_block_and_orbit
 using Crystalline
 
 @testset "Symmetry breaking" begin
@@ -72,6 +73,73 @@ using Crystalline
         tbm = tb_hamiltonian(cbr, [[0,0,0],])
 
         @test length(subduced_complement(tbm, 82)) == 2
+    end
+
+    @testset "composite band representations at a shared Wyckoff position" begin
+        # terms belonging to *different* blocks can carry equal (`==`) hopping orbits, if
+        # the associated band representations sit at the same Wyckoff position; such terms
+        # must not be grouped together, since they do not share a coefficient basis
+        brs = calc_bandreps(47, Val(3); timereversal = true) # P4/mmm
+        cbr = @composite brs[57] + brs[60] # (1a|Ag) + (1a|B₁ᵤ)
+
+        tbm = tb_hamiltonian(cbr, [[0,0,0]]) # on-site only: blocks (1,1) & (2,2), both δ=0
+        @test length(tbm) == 2
+        # subducing to G itself, with unchanged time-reversal, must give nothing new
+        @test length(subduced_complement(tbm, 47)) == 0
+        @test length(subduced_complement(tbm, 47; timereversal = false)) == 0
+
+        Rs = [[0,0,0], [1,0,0], [0,1,0], [0,0,1]]
+        tbm_nn = tb_hamiltonian(cbr, Rs)
+        @test length(tbm_nn) == 9
+        @test length(subduced_complement(tbm_nn, 47)) == 0
+        Δtbm_nn = subduced_complement(tbm_nn, 47; timereversal = false)
+        @test length(Δtbm_nn) == 1
+
+        # the complement must be *complete*: breaking time-reversal in G should give the
+        # same number of terms as building the model without time-reversal from the start
+        brs′ = calc_bandreps(47, Val(3); timereversal = false)
+        cbr′ = @composite brs′[57] + brs′[60] # same (1a|Ag) + (1a|B₁ᵤ) labels
+        @test length(tb_hamiltonian(cbr′, Rs)) == length(tbm_nn) + length(Δtbm_nn)
+
+        # the extended model must still be Hermitian
+        tbm′ = vcat(tbm_nn, Δtbm_nn)
+        ptbm′ = tbm′(rand(length(tbm′)))
+        for k in (ReciprocalPoint(0.1, 0.2, 0.3), ReciprocalPoint(0.5, 0.0, 0.25))
+            @test ptbm′(k) ≈ ptbm′(k)' # NB: `ptbm(k)` returns a reused buffer
+        end
+
+        # repeated band representations: blocks (1,1), (2,2), and (1,2) all share orbits
+        cbr2 = @composite brs[57] + brs[57] # 2 × (1a|Ag)
+        tbm2 = tb_hamiltonian(cbr2, [[0,0,0], [1,0,0]])
+        @test length(tbm2) == 6
+        @test length(subduced_complement(tbm2, 47)) == 0
+        @test length(subduced_complement(tbm2, 47; timereversal = false)) == 2
+    end
+
+    @testset "term grouping" begin
+        # terms sharing a coefficient basis must be grouped together regardless of whether
+        # they appear contiguously in the model (models may be built by `vcat` or indexing)
+        brs2d = calc_bandreps(11, Val(2); timereversal = true)
+        tbm = tb_hamiltonian((@composite brs2d[1]), [[0,0], [1,0]])
+        @test _group_terms_by_block_and_orbit(tbm) == [[1], [2], [3, 4], [5]]
+
+        p = [3, 1, 2, 4, 5] # splits the {3,4} group apart
+        @test _group_terms_by_block_and_orbit(tbm[p]) == [[1, 4], [2], [3], [5]]
+        for (sgnumᴴ, timereversal) in ((10, true), (6, true), (11, false), (10, false))
+            @test length(subduced_complement(tbm[p], sgnumᴴ; timereversal)) ==
+                  length(subduced_complement(tbm, sgnumᴴ; timereversal))
+        end
+
+        # equal-orbit terms from distinct blocks must stay in distinct groups, also when
+        # they are adjacent
+        brs = calc_bandreps(47, Val(3); timereversal = true)
+        tbm2 = tb_hamiltonian((@composite brs[57] + brs[57]), [[0,0,0], [1,0,0]])
+        q = [1, 3, 5, 2, 4, 6] # interleave, so that equal orbits become adjacent
+        @test [t.block_ij for t in tbm2.terms] ==
+              [(1,1), (1,1), (2,2), (2,2), (1,2), (1,2)]
+        @test _group_terms_by_block_and_orbit(tbm2[q]) == [[i] for i in 1:6]
+        @test length(subduced_complement(tbm2[q], 47; timereversal = false)) ==
+              length(subduced_complement(tbm2,    47; timereversal = false))
     end
 
     @testset "centered lattices" begin

--- a/test/symmetry-breaking.jl
+++ b/test/symmetry-breaking.jl
@@ -66,13 +66,28 @@ using Crystalline
         @test length(subduced_complement(tbm, 3)) == 1
     end
 
-    @testset "broken 3D example" begin
+    @testset "3D example, body-centered (I) lattice" begin
         brs = calc_bandreps(121, Val(3); timereversal = true)
         cbr = @composite brs[1] + brs[end-1] # (4d|A) + (2a|A₂) (3 bands)
         tbm = tb_hamiltonian(cbr, [[0,0,0],])
 
-        @test_broken subduced_complement(tbm, 82)
-        # ERROR: failed to find any nonzero block (br=(4d|A), siteg=[1, {2₁₁₀|1,0,1},
-        #        {-4₁₁₀⁺|1,0,0}, {-4₁₁₀⁻|1,1,1}] (4d: [3/4, 1/4, 1/2]), op=2₀₀₁)
+        @test length(subduced_complement(tbm, 82)) == 2
+    end
+
+    @testset "centered lattices" begin
+        # the subgroup generators must be converted to the primitive setting before the
+        # constraints are imposed; if not, centered lattices error out in
+        # `sgrep_induced_by_siteir` (which compares against primitivized site groups)
+        brs = calc_bandreps(12, Val(3); timereversal = true) # C2/m (C-centered)
+        cbr = @composite brs[1] # (4f|Ag)
+        tbm = tb_hamiltonian(cbr, [[0,0,0], [1,0,0]])
+        @test length(tbm) == 6
+
+        # subducing to G itself, with unchanged time-reversal, must give nothing new
+        @test length(subduced_complement(tbm, 12)) == 0
+
+        @test length(subduced_complement(tbm, 12; timereversal = false)) == 1 # break TR
+        @test length(subduced_complement(tbm, 5)) == 2                       # break mirror
+        @test length(subduced_complement(tbm, 8)) == 2                       # break C₂ & -1
     end
 end

--- a/test/symmetry-breaking.jl
+++ b/test/symmetry-breaking.jl
@@ -1,6 +1,7 @@
 using Test
 using SymmetricTightBinding
-using SymmetricTightBinding: _group_terms_by_block_and_orbit
+using SymmetricTightBinding: _group_terms_by_block_and_orbit, _subduced_complement,
+                             _issubgroup
 using Crystalline
 
 @testset "Symmetry breaking" begin
@@ -72,7 +73,19 @@ using Crystalline
         cbr = @composite brs[1] + brs[end-1] # (4d|A) + (2a|A₂) (3 bands)
         tbm = tb_hamiltonian(cbr, [[0,0,0],])
 
-        @test length(subduced_complement(tbm, 82)) == 2
+        Δtbm = subduced_complement(tbm, 82)
+        @test length(Δtbm) == 2
+
+        # completeness: `(4d|A)` of ⋕121 splits into `2c ⊕ 2d` in ⋕82, and `(2a|A₂)` maps
+        # to one of `(2a|A/B)`; every such 3-band composite of ⋕82 has 6 = 4 + 2 terms
+        brs82 = calc_bandreps(82, Val(3); timereversal = true)
+        for (i, j, k) in Iterators.product((4, 5), (1, 2), (10, 11)) # 2c, 2d, 2a
+            cbr82 = CompositeBandRep([n ∈ (i,j,k) ? 1 : 0 for n in eachindex(brs82)], brs82)
+            @test length(tb_hamiltonian(cbr82, [[0,0,0],])) == length(tbm) + length(Δtbm)
+        end
+
+        # having added the complement, there is nothing further to find in ⋕82
+        @test length(subduced_complement(vcat(tbm, Δtbm), 82)) == 0
     end
 
     @testset "composite band representations at a shared Wyckoff position" begin
@@ -98,7 +111,11 @@ using Crystalline
         # the complement must be *complete*: breaking time-reversal in G should give the
         # same number of terms as building the model without time-reversal from the start
         brs′ = calc_bandreps(47, Val(3); timereversal = false)
-        cbr′ = @composite brs′[57] + brs′[60] # same (1a|Ag) + (1a|B₁ᵤ) labels
+        cbr′ = @composite brs′[57] + brs′[60]
+        # ⋕57 & ⋕60 index the same band representations with and without time-reversal, but
+        # that is a property of `calc_bandreps`' ordering rather than something we control
+        @test string.((brs[57], brs[60])) == ("(1a|Ag)", "(1a|B₁ᵤ)")
+        @test string.((brs′[57], brs′[60])) == ("(1a|Ag)", "(1a|B₁ᵤ)")
         @test length(tb_hamiltonian(cbr′, Rs)) == length(tbm_nn) + length(Δtbm_nn)
 
         # the extended model must still be Hermitian
@@ -157,5 +174,17 @@ using Crystalline
         @test length(subduced_complement(tbm, 12; timereversal = false)) == 1 # break TR
         @test length(subduced_complement(tbm, 5)) == 2                       # break mirror
         @test length(subduced_complement(tbm, 8)) == 2                       # break C₂ & -1
+    end
+
+    @testset "subgroup precondition" begin
+        # `_subduced_complement` asserts that `gensᴴ` generate a subgroup of G, given in G's
+        # conventional setting; unreachable via `subduced_complement`, but check it can fire
+        brs2d = calc_bandreps(11, Val(2); timereversal = true) # p4mm
+        tbm = tb_hamiltonian((@composite brs2d[1]), [[0,0], [1,0]])
+
+        @test _issubgroup([S"y,x"], 11)     # mₓᵧ ∈ p4mm
+        @test !_issubgroup([S"-y,x+y"], 11) # 6⁺ ∉ p4mm
+        @test length(_subduced_complement(tbm, [S"y,x"])) isa Int
+        @test_throws AssertionError _subduced_complement(tbm, [S"-y,x+y"])
     end
 end


### PR DESCRIPTION
Fixes #114 and fixes #115 — two independent bugs in `subduced_complement`, one commit each.

## 1. Group terms by block *and* orbit (#114)

Terms must be grouped by shared coefficient basis, but the grouping was a run-length scan keyed only on `tbt.block.h_orbit`. `HoppingOrbit` compares structurally, so terms in *different* blocks whose band reps sit at the same Wyckoff position have equal orbits and were merged into one group; the basis was then computed for the first block only and its dimension compared against the merged count, tripping the "unexpectedly found lower-dimensional basis space" error.

Consequence: `subduced_complement` was unusable for any `CompositeBandRep` built from ≥2 band reps sharing a Wyckoff position — including for a no-op subduction G → G.

Now grouped by `(block_ij, h_orbit)` via `_group_terms_by_block_and_orbit`, which also drops the contiguity assumption. That second half is not cosmetic: when a group was split across two runs, the old scan **silently emitted duplicate terms**. For the p4mm model of the docs, permuting the term order changed `subduced_complement(tbm, 6)` from 4 terms to 8, with no error. Models assembled by `vcat` — which the `subduced_complement` docstring recommends — hit exactly this.

Both `error(...)` messages now name the offending block and orbit representative.

## 2. Primitivize the subgroup generators (#115)

`subduced_complement` passed `gensᴴ` to `_obtain_basis_free_parameters` in the conventional setting, while the constructor path (`obtain_basis_free_parameters`) passes primitive-setting generators. For centered lattices the constraints were imposed in the wrong basis and the call died in `sgrep_induced_by_siteir` with "failed to find any nonzero block".

This is the internal counterpart of #112: the conventional/primitive setting is implicit, so every call site has to remember to convert. `src/symmetry_breaking.jl:101` was the only `generators(...)` call site in `src/` without a paired `primitivize`.

It was also the real cause of the `@test_broken` for SG 121 → 82, whose comment blamed `sgrep_induced_by_siteir` itself; that is now a passing `@test`.

## Verification

Each row re-run against the pre-fix code:

| check | before | after |
|---|---|---|
| SG 47 `(1a\|Ag) + (1a\|B₁ᵤ)` on-site, no-op subduction | throws | 0 |
| SG 12 (C2/m) no-op subduction | throws | 0 |
| SG 121 → 82 (the `@test_broken`) | throws | 2 |
| p4mm, term order permuted, → SG 6 | **8** (silently wrong) | 4 |
| completeness: `tb_hamiltonian` w/o TR vs `tbm + Δtbm` (SG 47, NN) | — | 10 == 9 + 1 ✓ |

Full suite passes. `Symmetry breaking` goes 19 pass + 1 broken → 42 pass, 0 broken.

## Tests

In `test/symmetry-breaking.jl`:

- **`composite band representations at a shared Wyckoff position`** — SG 47 `(1a|Ag) + (1a|B₁ᵤ)` on-site and NN; no-op invariant (G → G with unchanged TRS ⇒ empty complement); completeness cross-check against building the TR-less model directly; Hermiticity of `vcat(tbm, Δtbm)`; and `2 × (1a|Ag)`, where blocks (1,1), (2,2), (1,2) all carry equal orbits.
- **`term grouping`** — asserts the grouping structure directly, and that permuting term order leaves the complement unchanged across four subgroup/TRS combinations. This is what pins the contiguity half.
- **`centered lattices`** — SG 12 (C2/m): no-op ⇒ 0, TR-breaking ⇒ 1, → SG 5 ⇒ 2, → SG 8 ⇒ 2.

The no-op invariant is the cheap one to reuse: it needs no independently known answer and would have caught both bugs.

## Deliberately not included

Separable, happy to do in follow-ups:

- `Base.hash`/`Base.isequal` for `HoppingOrbit`. It defines `==` but not `hash`, so it is not currently a valid `Dict`/`Set` key — that is why the grouping uses a linear scan rather than a `Dict`.
- Memoizing the H-basis per unique `(br1, br2, h_orbit, diagonal_block)`; composites with repeated band reps recompute an identical basis per copy (cf. #44).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
