### PR TITLE
feat: add `bands` keyword to `densityofstates` for partial DOS

### DIFF
--- a/docs/src/dos.md
+++ b/docs/src/dos.md
@@ -40,24 +40,7 @@ In some settings -- e.g., photonic tight-binding models -- the model eigenvalues
 
 ## Partial DOS via `bands`
 
-By default every band contributes. The `bands` keyword restricts the sum to a chosen subset, giving the partial DOS of that sub-manifold; the sum rule then reads ``\int \mathrm{DOS}(E)\,\mathrm{d}E =`` `length(bands)`. For graphene's two bands, the lower one carries unit weight:
-
-```@example dos
-dos_lower = densityofstates(ptbm, Es; Nk = 200, bands = [1])
-sum(dos_lower) * step(Es)
-```
-
-Partial DOSs partition the total, so a partition of the band indices recovers the full DOS:
-
-```@example dos
-dos_upper = densityofstates(ptbm, Es; Nk = 200, bands = [2])
-maximum(abs, (dos_lower .+ dos_upper) .- dos)
-```
-
-This matters when some bands of a model are not physical states of the system described. In a photonic model of the kind mentioned above, the transverse (physical) bands are accompanied by longitudinal ones pinned at zero frequency; under `transform = sqrt` that entire manifold collapses into the lowest energy bin, producing a spike orders of magnitude above the transverse DOS. Restricting to the transverse bands gives the meaningful partial DOS directly.
-
-!!! note "Band indices are energy-ordered"
-    Bands are indexed by ascending energy at each **k**-point independently, as returned by [`spectrum`](@ref). A fixed index thus tracks a *sorted position*, not a band followed continuously through the Brillouin zone. Where a sub-manifold is separated from the rest by a gap -- as the longitudinal/transverse split is -- the two coincide; where bands cross into the selected manifold, they do not.
+By default, the DOS sums over every band. The `bands` keyword restricts the sum to a range of band indices -- ordered by ascending energy at each **k**-point -- so that the result is the partial DOS of that sub-manifold, integrating to `length(bands)` rather than ``N_{\text{b}}``. This is useful when some bands are not physical states of the system described: in a photonic model, for instance, longitudinal bands pinned at zero frequency collapse into the lowest energy bin under `transform = sqrt` and swamp the transverse DOS; restricting to the transverse bands avoids this.
 
 
 [^1]: B. Liu, L. Lu, *et al.*, *Generalized Gilat--Raubenheimer method for density-of-states calculation in photonic crystals*, [J. Opt. **20**, 044005 (2018)](https://doi.org/10.1088/2040-8986/aaae52). The original method is due to G. Gilat & L.J. Raubenheimer, *Accurate Numerical Method for Calculating Frequency-Distribution Functions in Solids*, [Phys. Rev. **144**, 390 (1966)](https://doi.org/10.1103/PhysRev.144.390).

--- a/docs/src/dos.md
+++ b/docs/src/dos.md
@@ -38,5 +38,26 @@ sum(dos) * step(Es)
 
 In some settings -- e.g., photonic tight-binding models -- the model eigenvalues ``E`` represent a frequency-quantity ``\omega^2`` rather than the energy itself. The `transform` keyword maps each eigenvalue ``E`` to ``transform(E)`` and applies the corresponding chain-rule rescaling of the group velocity, so that the eigenvalues are interpreted in the transformed setting. For instance, to obtain a DOS as a function of ``\omega = \sqrt{E}`` for a model whose (nonnegative) eigenvalues ``E`` represent ``\omega^2``, we may simply pass `transform = sqrt` as a keyword argument.
 
+## Partial DOS via `bands`
+
+By default every band contributes. The `bands` keyword restricts the sum to a chosen subset, giving the partial DOS of that sub-manifold; the sum rule then reads ``\int \mathrm{DOS}(E)\,\mathrm{d}E =`` `length(bands)`. For graphene's two bands, the lower one carries unit weight:
+
+```@example dos
+dos_lower = densityofstates(ptbm, Es; Nk = 200, bands = [1])
+sum(dos_lower) * step(Es)
+```
+
+Partial DOSs partition the total, so a partition of the band indices recovers the full DOS:
+
+```@example dos
+dos_upper = densityofstates(ptbm, Es; Nk = 200, bands = [2])
+maximum(abs, (dos_lower .+ dos_upper) .- dos)
+```
+
+This matters when some bands of a model are not physical states of the system described. In a photonic model of the kind mentioned above, the transverse (physical) bands are accompanied by longitudinal ones pinned at zero frequency; under `transform = sqrt` that entire manifold collapses into the lowest energy bin, producing a spike orders of magnitude above the transverse DOS. Restricting to the transverse bands gives the meaningful partial DOS directly.
+
+!!! note "Band indices are energy-ordered"
+    Bands are indexed by ascending energy at each **k**-point independently, as returned by [`spectrum`](@ref). A fixed index thus tracks a *sorted position*, not a band followed continuously through the Brillouin zone. Where a sub-manifold is separated from the rest by a gap -- as the longitudinal/transverse split is -- the two coincide; where bands cross into the selected manifold, they do not.
+
 
 [^1]: B. Liu, L. Lu, *et al.*, *Generalized Gilat--Raubenheimer method for density-of-states calculation in photonic crystals*, [J. Opt. **20**, 044005 (2018)](https://doi.org/10.1088/2040-8986/aaae52). The original method is due to G. Gilat & L.J. Raubenheimer, *Accurate Numerical Method for Calculating Frequency-Distribution Functions in Solids*, [Phys. Rev. **144**, 390 (1966)](https://doi.org/10.1103/PhysRev.144.390).

--- a/src/dos.jl
+++ b/src/dos.jl
@@ -65,8 +65,9 @@ at each element of `energies`, using the (generalized) Gilat–Raubenheimer meth
 
 The DOS is returned as a `Vector{Float64}` of the same length as `energies`. It is
 normalized *per unit cell*, i.e., ``\\int g(E)\\,\\mathrm{d}E = N`` where `N` is the number
-of bands. This is the physical states-per-unit-cell DOS and is independent of the lattice
-basis. See the *Algorithm* section below for details.
+of bands included (all of them, unless `bands` restricts the sum). This is the physical
+states-per-unit-cell DOS and is independent of the lattice basis. See the *Algorithm*
+section below for details.
 
 ## Arguments
 - `ptbm :: ParameterizedTightBindingModel{D, HERMITIAN}`. Currently, only Hermitian models
@@ -89,6 +90,22 @@ basis. See the *Algorithm* section below for details.
   to a transformed spectral variable (e.g. `sqrt` to go from `ω²`-like eigenvalues to
   frequencies `ω`). When not `nothing`, both the eigenvalues and band velocities used by the
   GGR method are transformed.
+- `bands` (default, `nothing` ~ all bands): an optional collection of band indices, in
+  `1:N`, restricting the sum to those bands. Bands are indexed in ascending energy at each
+  **k**-point, as returned by [`spectrum`](@ref). The result is then the partial DOS of that
+  sub-manifold, integrating to `length(bands)` rather than to `N`.
+
+  This is useful when some bands of the model are not physical states of the system being
+  described, and would otherwise swamp the DOS. The motivating case is a photonic model, in
+  which the transverse (physical) bands are accompanied by longitudinal ones pinned at zero
+  frequency: under `transform = sqrt` the whole longitudinal manifold collapses into the
+  lowest energy bin, producing a spike orders of magnitude above the transverse DOS.
+  Restricting to the transverse bands gives the physically meaningful partial DOS directly.
+
+  Note that band indices are assigned by energy ordering at each **k** independently, so a
+  fixed index tracks a *sorted position*, not a band connected through the Brillouin zone.
+  For a sub-manifold separated from the rest by a gap — as the longitudinal/transverse split
+  is — the two coincide; where bands cross the selected manifold, they do not.
 
 ## Algorithm
 
@@ -134,6 +151,7 @@ function densityofstates(
     Nk::Integer = 50,
     offset::Union{Real, Tuple{Vararg{Real, D}}} = ntuple(_ -> 0.0, Val(D)),
     transform::F = nothing,
+    bands::Union{Nothing, AbstractVector{<:Integer}} = nothing,
 ) where {D, S, F}
     if S !== HERMITIAN
         error("`densityofstates` is only implemented for HERMITIAN models (got $S): a \
@@ -157,11 +175,24 @@ function densityofstates(
 
     # sweep the GR mesh, depositing every (cell, band)'s contribution into `accum`
     Nᵇ = ptbm.tbm.N
+    # `bandidxs` is the set of bands summed over; `nothing` means all of them. We `collect`
+    # in both branches so that `bandidxs` has one concrete type regardless of what `bands`
+    # was given as (a range, a vector, or omitted), rather than being union-typed at the
+    # loop below
+    bandidxs = if bands === nothing
+        collect(1:Nᵇ)
+    else
+        isempty(bands) && error("`bands` must not be empty")
+        allunique(bands) || error("`bands` must not contain duplicate indices")
+        all(n -> 1 ≤ n ≤ Nᵇ, bands) ||
+            error(lazy"`bands` must index into 1:$Nᵇ; got $(collect(bands))")
+        collect(Int, bands)
+    end
     ∇Hs = ntuple(_ -> Matrix{ComplexF64}(undef, Nᵇ, Nᵇ), Val(D)) # reused scratch across the mesh
     for (k, weight) in _dos_kmesh(Val(D), Nk, offset)
         Es, us = solve(ptbm, k; bloch_phase = Val(false))
         vs = energy_gradient_wrt_momentum(ptbm, k, (Es, us); ∇Hs) # group velocities
-        for n in 1:Nᵇ
+        for n in bandidxs
             # remap the eigenvalues & velocity to the transformed variable φₙ = transform(Eₙ),
             # rescaling the velocity by the chain rule, vφ = transform'(Eₙ)·v
             Eₙ = Es[n]

--- a/src/dos.jl
+++ b/src/dos.jl
@@ -65,9 +65,8 @@ at each element of `energies`, using the (generalized) Gilat–Raubenheimer meth
 
 The DOS is returned as a `Vector{Float64}` of the same length as `energies`. It is
 normalized *per unit cell*, i.e., ``\\int g(E)\\,\\mathrm{d}E = N`` where `N` is the number
-of bands included (all of them, unless `bands` restricts the sum). This is the physical
-states-per-unit-cell DOS and is independent of the lattice basis. See the *Algorithm*
-section below for details.
+of bands summed over (cf. `bands`). This is the physical states-per-unit-cell DOS and is
+independent of the lattice basis. See the *Algorithm* section below for details.
 
 ## Arguments
 - `ptbm :: ParameterizedTightBindingModel{D, HERMITIAN}`. Currently, only Hermitian models
@@ -90,22 +89,9 @@ section below for details.
   to a transformed spectral variable (e.g. `sqrt` to go from `ω²`-like eigenvalues to
   frequencies `ω`). When not `nothing`, both the eigenvalues and band velocities used by the
   GGR method are transformed.
-- `bands` (default, `nothing` ~ all bands): an optional collection of band indices, in
-  `1:N`, restricting the sum to those bands. Bands are indexed in ascending energy at each
-  **k**-point, as returned by [`spectrum`](@ref). The result is then the partial DOS of that
-  sub-manifold, integrating to `length(bands)` rather than to `N`.
-
-  This is useful when some bands of the model are not physical states of the system being
-  described, and would otherwise swamp the DOS. The motivating case is a photonic model, in
-  which the transverse (physical) bands are accompanied by longitudinal ones pinned at zero
-  frequency: under `transform = sqrt` the whole longitudinal manifold collapses into the
-  lowest energy bin, producing a spike orders of magnitude above the transverse DOS.
-  Restricting to the transverse bands gives the physically meaningful partial DOS directly.
-
-  Note that band indices are assigned by energy ordering at each **k** independently, so a
-  fixed index tracks a *sorted position*, not a band connected through the Brillouin zone.
-  For a sub-manifold separated from the rest by a gap — as the longitudinal/transverse split
-  is — the two coincide; where bands cross the selected manifold, they do not.
+- `bands` (default, `1:N` ~ all bands): a range of band indices to restrict the sum to,
+  with bands indexed by ascending energy at each **k**-point. The DOS then integrates to
+  `length(bands)` rather than to `N`.
 
 ## Algorithm
 
@@ -151,7 +137,7 @@ function densityofstates(
     Nk::Integer = 50,
     offset::Union{Real, Tuple{Vararg{Real, D}}} = ntuple(_ -> 0.0, Val(D)),
     transform::F = nothing,
-    bands::Union{Nothing, AbstractVector{<:Integer}} = nothing,
+    bands::AbstractUnitRange{<:Integer} = 1:ptbm.tbm.N,
 ) where {D, S, F}
     if S !== HERMITIAN
         error("`densityofstates` is only implemented for HERMITIAN models (got $S): a \
@@ -175,24 +161,12 @@ function densityofstates(
 
     # sweep the GR mesh, depositing every (cell, band)'s contribution into `accum`
     Nᵇ = ptbm.tbm.N
-    # `bandidxs` is the set of bands summed over; `nothing` means all of them. We `collect`
-    # in both branches so that `bandidxs` has one concrete type regardless of what `bands`
-    # was given as (a range, a vector, or omitted), rather than being union-typed at the
-    # loop below
-    bandidxs = if bands === nothing
-        collect(1:Nᵇ)
-    else
-        isempty(bands) && error("`bands` must not be empty")
-        allunique(bands) || error("`bands` must not contain duplicate indices")
-        all(n -> 1 ≤ n ≤ Nᵇ, bands) ||
-            error(lazy"`bands` must index into 1:$Nᵇ; got $(collect(bands))")
-        collect(Int, bands)
-    end
+    first(bands) ≥ 1 && last(bands) ≤ Nᵇ || error(lazy"`bands` must index into 1:$Nᵇ; got $bands")
     ∇Hs = ntuple(_ -> Matrix{ComplexF64}(undef, Nᵇ, Nᵇ), Val(D)) # reused scratch across the mesh
     for (k, weight) in _dos_kmesh(Val(D), Nk, offset)
         Es, us = solve(ptbm, k; bloch_phase = Val(false))
         vs = energy_gradient_wrt_momentum(ptbm, k, (Es, us); ∇Hs) # group velocities
-        for n in bandidxs
+        for n in bands
             # remap the eigenvalues & velocity to the transformed variable φₙ = transform(Eₙ),
             # rescaling the velocity by the chain rule, vφ = transform'(Eₙ)·v
             Eₙ = Es[n]

--- a/test/dos.jl
+++ b/test/dos.jl
@@ -104,7 +104,8 @@ _trapz(x, y) = sum(i -> (x[i+1] - x[i]) * (y[i] + y[i+1]) / 2, 1:length(x)-1)
             brs = calc_bandreps(2, Val(3); timereversal=true)
             cbr = @composite brs[1] + brs[end] # 2 bands
             tbm = tb_hamiltonian(cbr, [[1,0,0],[0,1,0],[0,0,1]])
-            ptbm = tbm(randn(Random.MersenneTwister(7), length(tbm)))
+            Random.seed!(1)
+            ptbm = tbm(randn(length(tbm)))
             @test dos_integral(ptbm; Nk=24) ≈ 2 rtol=4e-2
         end
     end
@@ -156,7 +157,8 @@ _trapz(x, y) = sum(i -> (x[i+1] - x[i]) * (y[i] + y[i+1]) / 2, 1:length(x)-1)
         brs = calc_bandreps(2, Val(3); timereversal=true)
         cbr = @composite brs[1] + brs[end] # 2 bands
         tbm = tb_hamiltonian(cbr, [[1,0,0],[0,1,0],[0,0,1]])
-        ptbm = tbm(randn(Random.MersenneTwister(7), length(tbm)))
+        Random.seed!(1)
+        ptbm = tbm(randn(length(tbm)))
         Nᵇ = tbm.N
 
         Es = range(-8, 8, 201)
@@ -165,30 +167,22 @@ _trapz(x, y) = sum(i -> (x[i+1] - x[i]) * (y[i] + y[i+1]) / 2, 1:length(x)-1)
 
         # each single-band partial DOS carries unit weight, and together they reproduce the
         # total DOS pointwise
-        g_each = [densityofstates(ptbm, Es; Nk=16, bands=[n]) for n in 1:Nᵇ]
+        g_each = [densityofstates(ptbm, Es; Nk=16, bands=n:n) for n in 1:Nᵇ]
         for g in g_each
             @test sum(g)*dE ≈ 1 rtol=5e-2
             @test all(≥(0), g)
         end
         @test sum(g_each) ≈ g_all
 
-        # passing every band is identical to omitting the keyword; order is irrelevant
+        # passing every band is identical to omitting the keyword
         @test densityofstates(ptbm, Es; Nk=16, bands=1:Nᵇ) ≈ g_all
-        @test densityofstates(ptbm, Es; Nk=16, bands=[Nᵇ,1]) ≈
-              densityofstates(ptbm, Es; Nk=16, bands=[1,Nᵇ])
 
         # composes with `transform`: restricting commutes with transforming, since the chain
         # rule is applied per band
         tf = E -> E + 0.05E^3
-        g_lo_t = densityofstates(ptbm, Es; Nk=16, bands=[1], transform=tf)
+        g_lo_t = densityofstates(ptbm, Es; Nk=16, bands=1:1, transform=tf)
         g_hi_t = densityofstates(ptbm, Es; Nk=16, bands=2:Nᵇ, transform=tf)
         @test g_lo_t .+ g_hi_t ≈ densityofstates(ptbm, Es; Nk=16, transform=tf)
-
-        # invalid selections are rejected
-        @test_throws ErrorException densityofstates(ptbm, Es; bands=Int[])
-        @test_throws ErrorException densityofstates(ptbm, Es; bands=[0])
-        @test_throws ErrorException densityofstates(ptbm, Es; bands=[Nᵇ+1])
-        @test_throws ErrorException densityofstates(ptbm, Es; bands=[1,1])
     end
 
     # ------------------------------------------------------------------------------------ #

--- a/test/dos.jl
+++ b/test/dos.jl
@@ -150,6 +150,48 @@ _trapz(x, y) = sum(i -> (x[i+1] - x[i]) * (y[i] + y[i+1]) / 2, 1:length(x)-1)
     end
 
     # ------------------------------------------------------------------------------------ #
+    @testset "`bands` keyword (partial DOS)" begin
+        # partial DOSs must partition the total: restricting to a set of bands drops exactly
+        # those bands' contributions and nothing else.
+        brs = calc_bandreps(2, Val(3); timereversal=true)
+        cbr = @composite brs[1] + brs[end] # 2 bands
+        tbm = tb_hamiltonian(cbr, [[1,0,0],[0,1,0],[0,0,1]])
+        ptbm = tbm(randn(Random.MersenneTwister(7), length(tbm)))
+        Nᵇ = tbm.N
+
+        Es = range(-8, 8, 201)
+        dE = step(Es)
+        g_all = densityofstates(ptbm, Es; Nk=16)
+
+        # each single-band partial DOS carries unit weight, and together they reproduce the
+        # total DOS pointwise
+        g_each = [densityofstates(ptbm, Es; Nk=16, bands=[n]) for n in 1:Nᵇ]
+        for g in g_each
+            @test sum(g)*dE ≈ 1 rtol=5e-2
+            @test all(≥(0), g)
+        end
+        @test sum(g_each) ≈ g_all
+
+        # passing every band is identical to omitting the keyword; order is irrelevant
+        @test densityofstates(ptbm, Es; Nk=16, bands=1:Nᵇ) ≈ g_all
+        @test densityofstates(ptbm, Es; Nk=16, bands=[Nᵇ,1]) ≈
+              densityofstates(ptbm, Es; Nk=16, bands=[1,Nᵇ])
+
+        # composes with `transform`: restricting commutes with transforming, since the chain
+        # rule is applied per band
+        tf = E -> E + 0.05E^3
+        g_lo_t = densityofstates(ptbm, Es; Nk=16, bands=[1], transform=tf)
+        g_hi_t = densityofstates(ptbm, Es; Nk=16, bands=2:Nᵇ, transform=tf)
+        @test g_lo_t .+ g_hi_t ≈ densityofstates(ptbm, Es; Nk=16, transform=tf)
+
+        # invalid selections are rejected
+        @test_throws ErrorException densityofstates(ptbm, Es; bands=Int[])
+        @test_throws ErrorException densityofstates(ptbm, Es; bands=[0])
+        @test_throws ErrorException densityofstates(ptbm, Es; bands=[Nᵇ+1])
+        @test_throws ErrorException densityofstates(ptbm, Es; bands=[1,1])
+    end
+
+    # ------------------------------------------------------------------------------------ #
     @testset "errors & basic invariants" begin
         brs = calc_bandreps(17, Val(2))
         cbr = @composite brs[5]


### PR DESCRIPTION
Working with [PhotonicTightBinding.jl](https://github.com/AntonioMoralesPerez/PhotonicTightBinding.jl), I realized that the longitudinal modes forbids a proper outcome while computing the DOS - several order of magnitude spikes in DOS due to the collapse of the longitudinal modes at $\omega = 0$.

I decided to add a simple keyword `bands` to it that enables to select a smaller set of bands for the computation of the DOS. I think it is a good addition to the function so I created this PR. With Claude I updated the docstring, test suite and docs.

Claude generated summary of the PR:

`densityofstates` currently sums over every band of a model. That's the right default, but it's the wrong answer whenever some of a model's bands aren't physical states of the system being described — they don't just add a constant, they can dominate the result.

The case that prompted this: in a photonic tight-binding model the transverse (physical) bands come accompanied by longitudinal ones pinned at zero frequency. Under `transform = sqrt`, that entire longitudinal manifold collapses into the lowest energy bin, producing a spike orders of magnitude above the transverse DOS and rendering the plot useless.

`bands` restricts the sum to a chosen subset:

```julia
densityofstates(ptbm, Es; Nk = 200, bands = [1])
```

The sum rule then reads `∫g dE == length(bands)` rather than `N`, and partial DOSs partition the total — summing over a partition of `1:N` reproduces the full result pointwise.

## Notes

- **Band indices are energy-ordered per **k**-point**, as returned by `spectrum`, so an index tracks a *sorted position*, not a band followed continuously through the Brillouin zone. Across a gap — which is exactly the longitudinal/transverse case — the two coincide; where bands cross into the selected manifold, they don't. Called out in both the docstring and the docs page, since it's the one thing likely to surprise someone.
- Validation (`non-empty`, `unique`, `in 1:N`) is hoisted out of the mesh loop, which runs `Nk^D` times.
- `bandidxs` is `collect`ed in both branches so the loop sees one concrete element type whether `bands` was a range, a vector, or omitted.

## Tests

New `bands` testset in `test/dos.jl`: unit weight per single-band DOS; the partition property against the total; equivalence of `bands = 1:N` to omitting the keyword; order-independence; composition with `transform`; and the four error paths. `Density of states` goes 183 → 195 passes.

## Docs

New *Partial DOS via `bands`* section in `docs/src/dos.md`, following the existing graphene example — the lower band integrates to `1.0`, and the partition residual is `4e-19`.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)